### PR TITLE
shim: distinguish between runtime id and container id

### DIFF
--- a/crates/shim/examples/empty_shim.rs
+++ b/crates/shim/examples/empty_shim.rs
@@ -29,6 +29,7 @@ impl shim::Shim for Service {
     type T = Service;
 
     fn new(
+        _runtime_id: &str,
         _id: &str,
         _namespace: &str,
         _publisher: shim::RemotePublisher,


### PR DESCRIPTION
There's a misuse of runtime id and container id in Shim::new(). Both
runtime id and container id are needed by shim implentions, so add
parameter `container id` to Shim::new().

Fixes: #13