### PR TITLE
[shim] Set the "child subreaper" attribute

### DIFF
--- a/crates/shim/src/reap.rs
+++ b/crates/shim/src/reap.rs
@@ -22,7 +22,7 @@ pub fn set_subreaper() -> Result<()> {
     use std::io::Error;
 
     // Safe because we trust the kernel and have checked the result.
-    let code = unsafe { libc::prctl(PR_SET_CHILD_SUBREAPER, 0, 0, 0) };
+    let code = unsafe { libc::prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0) };
     if code != 0 {
         Err(Error::from_raw_os_error(code))
     } else {


### PR DESCRIPTION
The shim process can have "child subreaper" attribute when arg2 is **nonzero**.
see: https://man7.org/linux/man-pages/man2/prctl.2.html