### PR TITLE
[shim] Fix socket binding address

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -253,11 +253,7 @@ where
             let task_service = create_task(Arc::new(Box::new(task)));
             let mut server = Server::new().register_service(task_service);
 
-            server = if flags.socket.is_empty() {
-                server.add_listener(SOCKET_FD)?
-            } else {
-                server.bind(&flags.socket)?
-            };
+            server = server.add_listener(SOCKET_FD)?;
 
             server.start()?;
 


### PR DESCRIPTION
As there is no need in "-socket" flag, we'd better use SOCKET_FD as the binding address of task server only.

If "-socket" flag was passed as socket path by the first start command, the second default command will failed with "Address in use" error because the socket was already passed to it by Fd mapping when spawn command. 

Signed-off-by: Burning <burning9699@gmail.com>