### PR TITLE
[runc] Add async feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ jobs:
       - run: cargo check --examples --tests --all-targets
       - run: cargo fmt --all -- --check --files-with-diff
       - run: cargo clippy --all-targets --all-features -- -D warnings
-      # runc::tests::test_exec needs $XDG_RUNTIME_DIR to be set
       - env:
+          # runc::tests::test_exec needs $XDG_RUNTIME_DIR to be set
           XDG_RUNTIME_DIR: /tmp/dummy-xdr
         run: |
           mkdir -p /tmp/dummy-xdr
+          cargo test
           cargo test --all-features
 
   deny:

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -9,11 +9,11 @@ keywords = ["containerd", "containers", "runc"]
 description = "A crate for consuming the runc binary in your Rust applications"
 homepage = "https://containerd.io"
 
+[features]
+async = ["tokio", "async-trait", "futures"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-async-trait = "0.1.52"
-futures = "0.3.19"
 libc = "0.2.112"
 log = "0.4.14"
 nix = "0.23.1"
@@ -25,5 +25,9 @@ serde_json = "1.0.74"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 time = { version = "0.3.7", features = ["serde", "std"] }
-tokio = { version = "1.15.0", features = ["full"] }
 uuid = { version = "0.8.2", features = ["v4"] }
+
+# Async dependencies
+tokio = { version = "1.15.0", features = ["full"], optional = true }
+async-trait = { version = "0.1.52", optional = true }
+futures = { version = "0.3.19", optional = true }

--- a/crates/runc/src/error.rs
+++ b/crates/runc/src/error.rs
@@ -69,6 +69,7 @@ pub enum Error {
     #[error("Runc IO unavailable: {0}")]
     UnavailableIO(io::Error),
 
+    #[cfg(feature = "async")]
     #[error("Runc command timed out: {0}")]
     CommandTimeout(tokio::time::error::Elapsed),
 


### PR DESCRIPTION
Add `async` feature to isolate dependencies.

This will allow to exclude unnecessary dependencies (like don't pull `tokio` if not using async rust)

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>