### PR TITLE
Remove runc dependency from shim crate

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -13,11 +13,14 @@ homepage = "https://containerd.io"
 async = []
 
 [dependencies]
+log = "0.4"
 nix = "0.23.1"
+libc = "0.2.95"
 time = { version = "0.3.7", features = ["serde", "std"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 oci-spec = "0.5.4"
+crossbeam = "0.8.1"
 
 containerd-shim = { path = "../shim", version = "0.2.0" }
 runc = { path = "../runc", version = "0.1.0" }

--- a/crates/runc-shim/src/io.rs
+++ b/crates/runc-shim/src/io.rs
@@ -14,23 +14,20 @@
    limitations under the License.
 */
 use std::fmt::Debug;
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use crossbeam::sync::WaitGroup;
 use log::debug;
-use nix::sys::termios::Termios;
+
+use containerd_shim::util::IntoOption;
+use containerd_shim::{
+    error::{Error, Result},
+    io_error,
+};
 use runc::io::{Io, NullIo, FIFO};
-
-use crate::error::{Error, Result};
-use crate::util::IntoOption;
-
-pub struct Console {
-    pub file: File,
-    pub termios: Termios,
-}
 
 pub fn spawn_copy<R: Read + Send + 'static, W: Write + Send + 'static>(
     mut from: R,

--- a/crates/runc-shim/src/main.rs
+++ b/crates/runc-shim/src/main.rs
@@ -13,8 +13,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
+mod container;
+mod io;
 mod runc;
 mod service;
+mod task;
 
 use crate::service::Service;
 

--- a/crates/runc-shim/src/runc.rs
+++ b/crates/runc-shim/src/runc.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, SyncSender};
 
 use containerd_shim as shim;
+
 use nix::sys::signal::kill;
 use nix::sys::stat::Mode;
 use nix::unistd::{mkdir, Pid};
@@ -28,14 +29,15 @@ use runc::console::{Console, ConsoleSocket};
 use runc::options::{CreateOpts, DeleteOpts, ExecOpts, GlobalOpts, KillOpts};
 use runc::utils::new_temp_console_socket;
 use shim::api::*;
-use shim::container::{CommonContainer, CommonProcess, Container, ContainerFactory, Process};
 use shim::error::{Error, Result};
-use shim::io::{create_io, Stdio};
 use shim::mount::mount_rootfs;
 use shim::protos::protobuf::{well_known_types::Timestamp, CodedInputStream, Message};
 use shim::util::{read_spec_from_file, write_options, write_runtime, IntoOption};
 use shim::{debug, error, other, other_error};
 use time::OffsetDateTime;
+
+use crate::container::{CommonContainer, CommonProcess, Container, ContainerFactory, Process};
+use crate::io::{create_io, Stdio};
 
 pub const DEFAULT_RUNC_ROOT: &str = "/run/containerd/runc";
 const INIT_PID_FILE: &str = "init.pid";

--- a/crates/runc-shim/src/service.rs
+++ b/crates/runc-shim/src/service.rs
@@ -21,18 +21,20 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use containerd_shim as shim;
-use runc::options::{DeleteOpts, GlobalOpts, DEFAULT_COMMAND};
+
 use shim::api::*;
-use shim::container::{Container, Process};
 use shim::error::{Error, Result};
 use shim::monitor::{monitor_subscribe, Subject, Subscription, Topic};
 use shim::protos::protobuf::SingularPtrField;
-use shim::task::ShimTask;
 use shim::util::{get_timestamp, read_options, read_runtime, read_spec_from_file, write_address};
 use shim::{debug, error, io_error, other_error, warn};
 use shim::{spawn, Config, ExitSignal, RemotePublisher, Shim, StartOpts};
 
+use runc::options::{DeleteOpts, GlobalOpts, DEFAULT_COMMAND};
+
+use crate::container::{Container, Process};
 use crate::runc::{RuncContainer, RuncFactory, DEFAULT_RUNC_ROOT};
+use crate::task::ShimTask;
 
 const GROUP_LABELS: [&str; 2] = [
     "io.containerd.runc.v2.group",

--- a/crates/runc-shim/src/task.rs
+++ b/crates/runc-shim/src/task.rs
@@ -19,14 +19,17 @@ use std::sync::{Arc, Mutex};
 
 use log::{debug, info};
 
-use crate::api::*;
+use containerd_shim as shim;
+
+use shim::api::*;
+use shim::protos::protobuf::well_known_types::Timestamp;
+use shim::protos::protobuf::SingularPtrField;
+use shim::util::IntoOption;
+use shim::Error;
+use shim::Task;
+use shim::{TtrpcContext, TtrpcResult};
+
 use crate::container::{Container, ContainerFactory};
-use crate::error::Error;
-use crate::protos::protobuf::well_known_types::Timestamp;
-use crate::protos::protobuf::SingularPtrField;
-use crate::protos::Task;
-use crate::util::IntoOption;
-use crate::{TtrpcContext, TtrpcResult};
 
 type ShutdownType = Box<dyn FnOnce() + Send + Sync>;
 

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -21,13 +21,11 @@ time = { version = "0.3.7", features = ["serde", "std"] }
 serde_json = "1.0.78"
 serde_derive = "1.0.136"
 serde = "1.0.136"
-crossbeam = "0.8.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 signal-hook = "0.3.13"
 oci-spec = "0.5.4"
 
 containerd-shim-protos = { path = "../shim-protos", version = "0.1.2" }
-runc = { path = "../runc" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -71,14 +71,11 @@ pub mod api {
     pub use super::protos::shim::shim::*;
 }
 mod args;
-pub mod container;
-pub mod io;
 mod logger;
 pub mod monitor;
 pub mod mount;
 mod publisher;
 mod reap;
-pub mod task;
 pub mod util;
 
 const TTRPC_ADDRESS: &str = "TTRPC_ADDRESS";


### PR DESCRIPTION
Remove runc dependency from `shim` crate (move to `shim-runc` crate).

shim crate expected to be implementation independent.
(though i'm sure we could extract some parts back to `shim` in future)

PTAL @jiangliu @Burning1020 

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>