### PR TITLE
Add containerd integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,62 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  integration:
+    name: Integration
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        containerd: [v1.5.9, v1.6.0]
+
+    steps:
+      - name: Checkout extensions
+        uses: actions/checkout@v2
+
+      - name: Install shim
+        run: |
+          cargo build --release --bin containerd-shim-runc-v2
+          sudo install -D ./target/release/containerd-shim-runc-v2 /usr/local/bin/
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.5'
+
+      # This step is required for containerd v1.5.x and below
+      - name: Setup GOPATH
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Checkout containerd
+        uses: actions/checkout@v2
+        with:
+          repository: containerd/containerd
+          path: src/github.com/containerd/containerd
+          ref: ${{ matrix.containerd }}
+
+      - name: Install containerd
+        env:
+          GOFLAGS: -modcacherw
+          CGO_ENABLED: 1
+        run: |
+          # Install containerd dependencies first
+          sudo apt-get install -y gperf
+          sudo -E PATH=$PATH script/setup/install-seccomp
+          sudo -E PATH=$PATH script/setup/install-runc
+          sudo -E PATH=$PATH script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
+          # Install containerd
+          make bin/containerd GO_BUILD_FLAGS="-mod=vendor" BUILDTAGS="no_btrfs"
+          sudo -E PATH=$PATH install bin/containerd /usr/local/bin/
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Integration
+        env:
+          GOPROXY: direct
+          TEST_RUNTIME: "io.containerd.runc.v2"
+        run: sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration TESTFLAGS_RACE=-race EXTRA_TESTFLAGS=-no-criu
+        working-directory: src/github.com/containerd/containerd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
 
       - name: Install shim
         run: |
-          cargo build --release --bin containerd-shim-runc-v2
-          sudo install -D ./target/release/containerd-shim-runc-v2 /usr/local/bin/
+          cargo build --release --bin containerd-shim-runc-v2-rs
+          sudo install -D ./target/release/containerd-shim-runc-v2-rs /usr/local/bin/
 
       - uses: actions/setup-go@v2
         with:
@@ -104,6 +104,6 @@ jobs:
       - name: Integration
         env:
           GOPROXY: direct
-          TEST_RUNTIME: "io.containerd.runc.v2"
+          TEST_RUNTIME: "io.containerd.runc.v2-rs"
         run: sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration TESTFLAGS_RACE=-race EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd

--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "containerd-shim-runc-v2"
+name = "containerd-runc-shim"
 version = "0.1.0"
 authors = ["Shaobao Feng <fshb1988@gmail.com>", "Tianyang Zhang <burning9699@gmail.com>", "The containerd Authors"]
 edition = "2018"
@@ -8,6 +8,14 @@ repository = "https://github.com/containerd/rust-extensions"
 keywords = ["containerd", "shim", "containers"]
 description = "Rust implementation of containerd's runc v2 shim runtime"
 homepage = "https://containerd.io"
+
+[[bin]]
+# Overwrite the binary name so it can be referred as "io.containerd.runc.v2-rs" from containerd.
+# Note: the runtime's binary name must start with "io.containerd.runc" in order to
+# keep compatibility with Go runc runtime and the containerd client.
+# Example: https://github.com/containerd/containerd/blob/8047eb2fcac1f4553ee7652862194b1e10855ce7/task_opts_unix.go#L33
+name = "containerd-shim-runc-v2-rs"
+path = "src/main.rs"
 
 [features]
 async = ["containerd-shim/async", "runc/async", "tokio", "futures", "async-trait"]
@@ -21,6 +29,8 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 oci-spec = "0.5.4"
 crossbeam = "0.8.1"
+
+# Async dependencies
 async-trait = { version = "0.1.51", optional = true }
 tokio = { version = "1.17.0", features = ["full"], optional = true }
 futures = {version = "0.3.21", optional = true}

--- a/crates/runc-shim/src/main.rs
+++ b/crates/runc-shim/src/main.rs
@@ -22,14 +22,14 @@ mod synchronous;
 
 #[cfg(not(feature = "async"))]
 fn main() {
-    containerd_shim::run::<synchronous::Service>("io.containerd.runc.v2", None)
+    containerd_shim::run::<synchronous::Service>("io.containerd.runc.v2-rs", None)
 }
 
 #[cfg(feature = "async")]
 #[tokio::main]
 async fn main() {
     containerd_shim::asynchronous::run::<crate::asynchronous::Service>(
-        "io.containerd.runc.v2",
+        "io.containerd.runc.v2-rs",
         None,
     )
     .await;

--- a/crates/runc-shim/src/synchronous/task.rs
+++ b/crates/runc-shim/src/synchronous/task.rs
@@ -15,6 +15,7 @@
 */
 
 use std::collections::HashMap;
+use std::process;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, Once};
 
@@ -337,5 +338,22 @@ where
         });
 
         Ok(Empty::default())
+    }
+
+    fn connect(&self, _ctx: &TtrpcContext, req: ConnectRequest) -> TtrpcResult<ConnectResponse> {
+        info!("Connect request for {:?}", req);
+
+        let containers = self.containers.lock().unwrap();
+        let container = containers.get(req.get_id()).ok_or_else(|| {
+            Error::NotFoundError(format!("can not find container by id {}", req.get_id()))
+        })?;
+
+        let resp = ConnectResponse {
+            shim_pid: process::id() as u32,
+            task_pid: container.pid() as u32,
+            ..Default::default()
+        };
+
+        Ok(resp)
     }
 }


### PR DESCRIPTION
Enable integration test for runc-shim to make sure we're compliant with go version.

Fixes: https://github.com/containerd/rust-extensions/issues/6

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>