### PR TITLE
runc: fix bug that exec command leaks files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ members = [
     "crates/runc",
     "crates/runc-shim",
 ]
+
+[profile.release]
+# Keep binary as small as possible
+# https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html
+panic = 'abort'

--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -25,7 +25,3 @@ crossbeam = "0.8.1"
 containerd-shim = { path = "../shim", version = "0.2.0" }
 runc = { path = "../runc", version = "0.1.0" }
 
-[profile.release]
-# Keep binary as small as possible
-# https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html
-panic = 'abort'

--- a/crates/runc/src/utils.rs
+++ b/crates/runc/src/utils.rs
@@ -95,6 +95,7 @@ pub fn make_temp_file_in_runtime_dir() -> Result<(NamedTempFile, String), Error>
     let file_name = temp_filename_in_runtime_dir()?;
     let temp_file = Builder::new()
         .prefix(&file_name)
+        .rand_bytes(0)
         .tempfile()
         .map_err(Error::SpecFileCreationFailed)?;
     Ok((temp_file, file_name))


### PR DESCRIPTION
Fix bugs: Exec command will create a tmp file to store process spec json, this file should be removed after used otherwse it will be left on the host.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>