### PR TITLE
Bug fixes and improvements to the runc crate

### DIFF
--- a/crates/runc/src/io.rs
+++ b/crates/runc/src/io.rs
@@ -18,6 +18,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{Read, Result, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::process::Stdio;
 use std::sync::Mutex;
 
 use log::debug;
@@ -69,6 +70,7 @@ impl Default for IOOption {
 
 /// Struct to represent a pipe that can be used to transfer stdio inputs and outputs.
 ///
+/// With this Io driver, methods of [crate::Runc] may capture the output/error messages.
 /// When one side of the pipe is closed, the state will be represented with [`None`].
 #[derive(Debug)]
 pub struct Pipe {
@@ -183,7 +185,9 @@ impl Io for PipedIo {
     }
 }
 
-// IO setup for /dev/null use with runc
+/// IO driver to direct output/error messages to /dev/null.
+///
+/// With this Io driver, all methods of [crate::Runc] can't capture the output/error messages.
 #[derive(Debug)]
 pub struct NullIo {
     dev_null: Mutex<Option<File>>,
@@ -214,6 +218,52 @@ impl Io for NullIo {
         let mut m = self.dev_null.lock().unwrap();
         let _ = m.take();
     }
+}
+
+/// Io driver based on Stdio::inherited(), to direct outputs/errors to stdio.
+///
+/// With this Io driver, all methods of [crate::Runc] can't capture the output/error messages.
+#[derive(Debug)]
+pub struct InheritedStdIo {}
+
+impl InheritedStdIo {
+    pub fn new() -> std::io::Result<Self> {
+        Ok(InheritedStdIo {})
+    }
+}
+
+impl Io for InheritedStdIo {
+    fn set(&self, cmd: &mut Command) -> std::io::Result<()> {
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+        Ok(())
+    }
+
+    fn close_after_start(&self) {}
+}
+
+/// Io driver based on Stdio::piped(), to capture outputs/errors from runC.
+///
+/// With this Io driver, methods of [crate::Runc] may capture the output/error messages.
+#[derive(Debug)]
+pub struct PipedStdIo {}
+
+impl PipedStdIo {
+    pub fn new() -> std::io::Result<Self> {
+        Ok(PipedStdIo {})
+    }
+}
+
+impl Io for PipedStdIo {
+    fn set(&self, cmd: &mut Command) -> std::io::Result<()> {
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        Ok(())
+    }
+
+    fn close_after_start(&self) {}
 }
 
 /// FIFO for the scenario that set FIFO for command Io.

--- a/crates/runc/src/io.rs
+++ b/crates/runc/src/io.rs
@@ -89,6 +89,7 @@ impl Pipe {
         Ok(Self { rd, wr })
     }
 }
+
 impl PipedIo {
     pub fn new(uid: u32, gid: u32, opts: &IOOption) -> std::io::Result<Self> {
         Ok(Self {

--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -33,9 +33,8 @@
  * limitations under the License.
  */
 
-//! A crate for consuming the runc binary in your Rust applications, similar to [go-runc](https://github.com/containerd/go-runc) for Go.
-#![allow(unused)]
-
+//! A crate for consuming the runc binary in your Rust applications, similar to
+//! [go-runc](https://github.com/containerd/go-runc) for Go.
 use std::fmt::{self, Display};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -247,6 +246,7 @@ impl Runc {
         let args = ["list".to_string(), "--format-json".to_string()];
         let res = self.launch(self.command(&args)?, true)?;
         let output = res.output.trim();
+
         // Ugly hack to work around golang
         Ok(if output == "null" {
             Vec::new()
@@ -468,6 +468,7 @@ impl Runc {
         let args = ["list".to_string(), "--format-json".to_string()];
         let res = self.launch(self.command(&args)?, true).await?;
         let output = res.output.trim();
+
         // Ugly hack to work around golang
         Ok(if output == "null" {
             Vec::new()
@@ -507,6 +508,7 @@ impl Runc {
         ];
         let res = self.launch(self.command(&args)?, true).await?;
         let output = res.output.trim();
+
         // Ugly hack to work around golang
         Ok(if output == "null" {
             Vec::new()
@@ -580,7 +582,6 @@ impl Runc {
         Ok(())
     }
 }
-//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 #[cfg(test)]
 #[cfg(all(target_os = "linux", not(feature = "async")))]
@@ -648,10 +649,13 @@ mod tests {
     fn test_run() {
         let opts = CreateOpts::new();
         let ok_runc = ok_client();
-        ok_runc
+        let response = ok_runc
             .run("fake-id", "fake-bundle", Some(&opts))
             .expect("true failed.");
-        eprintln!("ok_runc succeeded.");
+        assert_ne!(response.pid, 0);
+        assert!(response.status.success());
+        assert!(response.output.is_empty());
+
         let fail_runc = fail_client();
         match fail_runc.run("fake-id", "fake-bundle", Some(&opts)) {
             Ok(_) => panic!("fail_runc returned exit status 0."),

--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -146,8 +146,9 @@ impl Runc {
         let pid = child.id();
         let result = child.wait_with_output().map_err(Error::InvalidCommand)?;
         let status = result.status;
-        let stdout = String::from_utf8(result.stdout).unwrap();
-        let stderr = String::from_utf8(result.stderr).unwrap();
+        let stdout = String::from_utf8_lossy(&result.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&result.stderr).to_string();
+
         if status.success() {
             if combined_output {
                 Ok(Response {


### PR DESCRIPTION
Bug fixes and improvements to the runc crate:
1) avoid unwrap() in launch()
2) fixes several bugs in command line preparation
3) refine the way to setup IO for runc.