### PR TITLE
Rework exit signals and task creation

### DIFF
--- a/crates/runc-shim/src/service.rs
+++ b/crates/runc-shim/src/service.rs
@@ -57,15 +57,13 @@ impl Shim for Service {
         _publisher: RemotePublisher,
         _config: &mut Config,
     ) -> Self {
-        let mut service = Service {
+        // TODO: add publisher
+
+        Service {
             exit: Arc::new(ExitSignal::default()),
             id: id.to_string(),
             namespace: namespace.to_string(),
-        };
-
-        // TODO: add publisher
-
-        service
+        }
     }
 
     fn start_shim(&mut self, opts: StartOpts) -> Result<String> {

--- a/crates/shim/examples/skeleton.rs
+++ b/crates/shim/examples/skeleton.rs
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+use std::sync::Arc;
+
 use containerd_shim as shim;
 
 use log::info;
@@ -21,7 +23,7 @@ use shim::{api, Config, DeleteResponse, ExitSignal, RemotePublisher, TtrpcContex
 
 #[derive(Clone)]
 struct Service {
-    exit: ExitSignal,
+    exit: Arc<ExitSignal>,
 }
 
 impl shim::Shim for Service {
@@ -35,7 +37,7 @@ impl shim::Shim for Service {
         _config: &mut Config,
     ) -> Self {
         Service {
-            exit: ExitSignal::default(),
+            exit: Arc::new(ExitSignal::default()),
         }
     }
 
@@ -53,7 +55,7 @@ impl shim::Shim for Service {
         self.exit.wait();
     }
 
-    fn get_task_service(&self) -> Self::T {
+    fn create_task_service(&self) -> Self::T {
         self.clone()
     }
 }

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -113,9 +113,11 @@ pub struct StartOpts {
 /// Helper structure that wraps atomic bool to signal shim server when to shutdown the TTRPC server.
 ///
 /// Shim implementations are responsible for calling [`Self::signal`].
+#[allow(clippy::mutex_atomic)] // Condvar expected to be used with Mutex, not AtomicBool.
 #[derive(Default)]
 pub struct ExitSignal(Mutex<bool>, Condvar);
 
+#[allow(clippy::mutex_atomic)]
 impl ExitSignal {
     /// Set exit signal to shutdown shim server.
     pub fn signal(&self) {


### PR DESCRIPTION
- `ExitSignal` is no longer `Arc`. Don't add extra overhead by default, its up to runtime implementations whether they need to count references. 
- Renames `get_task_service` to `create_task_service` to highlight that we expect task service to be created from there (and don't do clonable objects).
- Create `ShimTask` from `create_task_service` to avoid extra creation during `shim --start` call.
- Replaces `Arc<Mutex<Option<ShutdownType>>>` with `Once`. 

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>