### PR TITLE
shim: refine set subreaper

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1.0.136"
 uuid = { version = "0.8.2", features = ["v4"] }
 signal-hook = "0.3.13"
 oci-spec = "0.5.4"
+prctl = "1.0.0"
 
 containerd-shim-protos = { path = "../shim-protos", version = "0.1.2" }
 

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -207,7 +207,7 @@ where
     let signals = setup_signals(&config);
 
     if !config.no_sub_reaper {
-        reap::set_subreaper().map_err(io_error!(e, "set subreaper"))?;
+        reap::set_subreaper()?;
     }
 
     let mut shim = T::new(


### PR DESCRIPTION
It's better to get rid of invoking "unsafe" libc function directly in `set_subreaper()` though we know it's quite safe in fact.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>