### PR TITLE
runc-shim: support remote publisher and extra some common methods

### DIFF
--- a/crates/runc-shim/src/asynchronous/mod.rs
+++ b/crates/runc-shim/src/asynchronous/mod.rs
@@ -101,7 +101,7 @@ impl Shim for Service {
             namespace,
             &bundle,
             &opts,
-            Some(Arc::new(ShimExecutor {})),
+            Some(Arc::new(ShimExecutor::default())),
         )?;
 
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))

--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -38,12 +38,12 @@ use containerd_shim::asynchronous::monitor::{
     monitor_subscribe, monitor_unsubscribe, Subscription,
 };
 use containerd_shim::asynchronous::processes::{ProcessLifecycle, ProcessTemplate};
-use containerd_shim::asynchronous::util::{
-    asyncify, mkdir, mount_rootfs, read_file_to_str, read_spec, write_options, write_runtime,
-};
 use containerd_shim::io::Stdio;
 use containerd_shim::monitor::{ExitEvent, Subject, Topic};
 use containerd_shim::protos::protobuf::{CodedInputStream, Message};
+use containerd_shim::util::{
+    asyncify, mkdir, mount_rootfs, read_file_to_str, read_spec, write_options, write_runtime,
+};
 use containerd_shim::Console;
 use containerd_shim::{io_error, other, Error};
 use containerd_shim::{other_error, Result};

--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -97,7 +97,13 @@ impl ContainerFactory<RuncContainer> for RuncFactory {
             mount_rootfs(&m, rootfs.as_path()).await?
         }
 
-        let runc = create_runc(runtime, ns, bundle, &opts, Some(Arc::new(ShimExecutor {})))?;
+        let runc = create_runc(
+            runtime,
+            ns,
+            bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
 
         let id = req.get_id();
         let stdio = Stdio::new(

--- a/crates/runc-shim/src/common.rs
+++ b/crates/runc-shim/src/common.rs
@@ -98,7 +98,7 @@ pub fn create_io(
     Ok(pio)
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct ShimExecutor {}
 
 pub fn get_spec_from_request(

--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -44,9 +44,7 @@ use shim::protos::protobuf::well_known_types::{Any, Timestamp};
 use shim::protos::protobuf::{CodedInputStream, Message, RepeatedField};
 use shim::protos::shim::oci::ProcessDetails;
 #[cfg(not(feature = "async"))]
-use shim::util::{
-    new_temp_console_socket, read_spec_from_file, write_options, write_runtime, IntoOption,
-};
+use shim::util::{read_spec_from_file, write_options, write_runtime, IntoOption};
 use shim::Console;
 use shim::{other, other_error};
 
@@ -166,7 +164,7 @@ impl Container for RuncContainer {
                 };
                 let terminal = process.common.stdio.terminal;
                 let socket = if terminal {
-                    let s = new_temp_console_socket().map_err(other_error!(e, ""))?;
+                    let s = ConsoleSocket::new()?;
                     exec_opts.console_socket = Some(s.path.to_owned());
                     Some(s)
                 } else {
@@ -456,7 +454,7 @@ impl InitProcess {
             .no_new_keyring(self.no_new_key_ring)
             .detach(false);
         let socket = if terminal {
-            let s = new_temp_console_socket().map_err(other_error!(e, ""))?;
+            let s = ConsoleSocket::new()?;
             create_opts.console_socket = Some(s.path.to_owned());
             Some(s)
         } else {

--- a/crates/runc-shim/src/synchronous/service.rs
+++ b/crates/runc-shim/src/synchronous/service.rs
@@ -32,7 +32,7 @@ use shim::util::get_timestamp;
 use shim::{debug, error, io_error, other_error, warn};
 use shim::{spawn, Config, ExitSignal, Shim, StartOpts};
 
-use crate::common::{create_runc, GROUP_LABELS};
+use crate::common::{create_runc, ShimExecutor, GROUP_LABELS};
 use crate::synchronous::container::{Container, Process};
 use crate::synchronous::runc::{RuncContainer, RuncFactory};
 use crate::synchronous::task::ShimTask;
@@ -88,7 +88,13 @@ impl Shim for Service {
         let opts = read_options(&bundle)?;
         let runtime = read_runtime(&bundle)?;
 
-        let runc = create_runc(&*runtime, namespace, &bundle, &opts, None)?;
+        let runc = create_runc(
+            &*runtime,
+            namespace,
+            &bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))
             .unwrap_or_else(|e| warn!("failed to remove runc container: {}", e));
         let mut resp = DeleteResponse::new();

--- a/crates/runc/src/utils.rs
+++ b/crates/runc/src/utils.rs
@@ -61,8 +61,8 @@ where
     path_to_string(abs_path_buf(path)?)
 }
 
-/// Fetches the value of environment variable "XDG_RUNTIME_DIR", returning a temporary directory
-/// if the variable isn't set
+/// Returns a temp dir. If the environment variable "XDG_RUNTIME_DIR" is set, return its value.
+/// Otherwise if `std::env::temp_dir()` failed, return current dir or return the temp dir depended on OS.
 fn xdg_runtime_dir() -> String {
     env::var("XDG_RUNTIME_DIR")
         .unwrap_or_else(|_| abs_string(env::temp_dir()).unwrap_or_else(|_| ".".to_string()))

--- a/crates/shim/examples/publish.rs
+++ b/crates/shim/examples/publish.rs
@@ -41,7 +41,7 @@ fn main() {
     println!("Sending event");
 
     publisher
-        .publish(ctx, "/tasks/oom", "default", event)
+        .publish(ctx, "/tasks/oom", "default", Box::new(event))
         .expect("Publish failed");
 
     println!("Done");
@@ -70,7 +70,7 @@ async fn main() {
     println!("Sending event");
 
     publisher
-        .publish(ctx, "/tasks/oom", "default", event)
+        .publish(ctx, "/tasks/oom", "default", Box::new(event))
         .await
         .expect("Publish failed");
 

--- a/crates/shim/examples/skeleton.rs
+++ b/crates/shim/examples/skeleton.rs
@@ -23,7 +23,7 @@ mod skeleton {
     use log::info;
 
     use containerd_shim as shim;
-    use containerd_shim::synchronous::publisher::RemotePublisher;
+    use shim::synchronous::publisher::RemotePublisher;
     use shim::{api, Config, DeleteResponse, ExitSignal, TtrpcContext, TtrpcResult};
 
     #[derive(Clone)]
@@ -34,13 +34,7 @@ mod skeleton {
     impl shim::Shim for Service {
         type T = Service;
 
-        fn new(
-            _runtime_id: &str,
-            _id: &str,
-            _namespace: &str,
-            _publisher: RemotePublisher,
-            _config: &mut Config,
-        ) -> Self {
+        fn new(_runtime_id: &str, _id: &str, _namespace: &str, _config: &mut Config) -> Self {
             Service {
                 exit: Arc::new(ExitSignal::default()),
             }
@@ -60,7 +54,7 @@ mod skeleton {
             self.exit.wait();
         }
 
-        fn create_task_service(&self) -> Self::T {
+        fn create_task_service(&self, _publisher: RemotePublisher) -> Self::T {
             self.clone()
         }
     }

--- a/crates/shim/examples/skeleton_async.rs
+++ b/crates/shim/examples/skeleton_async.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use log::info;
 
-use containerd_shim::asynchronous::publisher::RemotePublisher;
 use containerd_shim::asynchronous::{run, spawn, ExitSignal, Shim};
+use containerd_shim::publisher::RemotePublisher;
 use containerd_shim::{Config, Error, StartOpts, TtrpcResult};
 use containerd_shim_protos::api;
 use containerd_shim_protos::api::DeleteResponse;
@@ -36,13 +36,7 @@ struct Service {
 impl Shim for Service {
     type T = Service;
 
-    async fn new(
-        _runtime_id: &str,
-        _id: &str,
-        _namespace: &str,
-        _publisher: RemotePublisher,
-        _config: &mut Config,
-    ) -> Self {
+    async fn new(_runtime_id: &str, _id: &str, _namespace: &str, _config: &mut Config) -> Self {
         Service {
             exit: Arc::new(ExitSignal::default()),
         }
@@ -62,7 +56,7 @@ impl Shim for Service {
         self.exit.wait().await;
     }
 
-    async fn create_task_service(&self) -> Self::T {
+    async fn create_task_service(&self, _publisher: RemotePublisher) -> Self::T {
         self.clone()
     }
 }

--- a/crates/shim/src/asynchronous/console.rs
+++ b/crates/shim/src/asynchronous/console.rs
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 
-use std::env;
 use std::path::{Path, PathBuf};
 
 use log::warn;
@@ -22,6 +21,7 @@ use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
 use crate::asynchronous::util::mkdir;
+use crate::util::xdg_runtime_dir;
 use crate::Error;
 use crate::Result;
 
@@ -33,8 +33,7 @@ pub struct ConsoleSocket {
 
 impl ConsoleSocket {
     pub async fn new() -> Result<ConsoleSocket> {
-        let dir = env::var("XDG_RUNTIME_DIR")
-            .map(|runtime_dir| format!("{}/pty{}", runtime_dir, Uuid::new_v4(),))?;
+        let dir = format!("{}/pty{}", xdg_runtime_dir(), Uuid::new_v4());
         mkdir(&dir, 0o711).await?;
         let file_name = Path::new(&dir).join("pty.sock");
         let listener = UnixListener::bind(&file_name).map_err(io_error!(

--- a/crates/shim/src/asynchronous/console.rs
+++ b/crates/shim/src/asynchronous/console.rs
@@ -20,8 +20,7 @@ use log::warn;
 use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
-use crate::asynchronous::util::mkdir;
-use crate::util::xdg_runtime_dir;
+use crate::util::{mkdir, xdg_runtime_dir};
 use crate::Error;
 use crate::Result;
 

--- a/crates/shim/src/asynchronous/processes.rs
+++ b/crates/shim/src/asynchronous/processes.rs
@@ -23,8 +23,8 @@ use tokio::sync::oneshot::{channel, Receiver, Sender};
 use containerd_shim_protos::api::{StateResponse, Status};
 use containerd_shim_protos::protobuf::well_known_types::Timestamp;
 
-use crate::asynchronous::util::asyncify;
 use crate::io::Stdio;
+use crate::util::asyncify;
 use crate::Error;
 use crate::{ioctl_set_winsz, Console};
 

--- a/crates/shim/src/asynchronous/util.rs
+++ b/crates/shim/src/asynchronous/util.rs
@@ -142,7 +142,7 @@ pub async fn mkdir(path: impl AsRef<Path>, mode: mode_t) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::asynchronous::util::{read_file_to_str, write_str_to_file};
+    use crate::util::{read_file_to_str, write_str_to_file};
 
     #[tokio::test]
     async fn test_read_write_str() {

--- a/crates/shim/src/event.rs
+++ b/crates/shim/src/event.rs
@@ -1,0 +1,66 @@
+use containerd_shim_protos::events::task::*;
+use containerd_shim_protos::protobuf::Message;
+
+pub trait Event: Message {
+    fn topic(&self) -> String;
+}
+
+impl Event for TaskCreate {
+    fn topic(&self) -> String {
+        "/tasks/create".to_string()
+    }
+}
+
+impl Event for TaskStart {
+    fn topic(&self) -> String {
+        "/tasks/start".to_string()
+    }
+}
+
+impl Event for TaskExecAdded {
+    fn topic(&self) -> String {
+        "/tasks/exec-added".to_string()
+    }
+}
+
+impl Event for TaskExecStarted {
+    fn topic(&self) -> String {
+        "/tasks/exec-started".to_string()
+    }
+}
+
+impl Event for TaskPaused {
+    fn topic(&self) -> String {
+        "/tasks/paused".to_string()
+    }
+}
+
+impl Event for TaskResumed {
+    fn topic(&self) -> String {
+        "/tasks/resumed".to_string()
+    }
+}
+
+impl Event for TaskExit {
+    fn topic(&self) -> String {
+        "/tasks/exit".to_string()
+    }
+}
+
+impl Event for TaskDelete {
+    fn topic(&self) -> String {
+        "/tasks/delete".to_string()
+    }
+}
+
+impl Event for TaskOOM {
+    fn topic(&self) -> String {
+        "/tasks/oom".to_string()
+    }
+}
+
+impl Event for TaskCheckpointed {
+    fn topic(&self) -> String {
+        "/tasks/checkpointed".to_string()
+    }
+}

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -56,6 +56,7 @@ pub mod error;
 mod args;
 #[cfg(feature = "async")]
 pub mod asynchronous;
+pub mod event;
 pub mod io;
 mod logger;
 pub mod monitor;

--- a/crates/shim/src/util.rs
+++ b/crates/shim/src/util.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use std::env;
 use std::os::unix::io::RawFd;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -153,6 +154,13 @@ pub fn any(event: impl Message) -> Result<Any> {
     any.merge_from_bytes(&data)?;
 
     Ok(any)
+}
+
+/// Returns a temp dir. If the environment variable "XDG_RUNTIME_DIR" is set, return its value.
+/// Otherwise if `std::env::temp_dir()` failed, return current dir or return the temp dir depended on OS.
+pub(crate) fn xdg_runtime_dir() -> String {
+    env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| env::temp_dir().to_str().unwrap_or(".").to_string())
 }
 
 pub trait IntoOption


### PR DESCRIPTION
Allow shim publish task event to containerd, and also extra some common convert methods
Signed-off-by: Zhang Tianyang <burning9699@gmail.com>