### PR TITLE
[runc/shim] removed some unsafe codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout extensions
         uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.17.5'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        containerd: [v1.5.9, v1.6.0]
+        containerd: [v1.5.11, v1.6.2]
 
     steps:
       - name: Checkout extensions

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,14 +11,14 @@ categories = ["api-bindings", "asynchronous"]
 homepage = "https://containerd.io"
 
 [dependencies]
-tonic = "0.6"
-prost = "0.9"
-prost-types = "0.9"
-tokio = { version = "1.15.0", optional = true }
+tonic = "0.7"
+prost = "0.10"
+prost-types = "0.10"
+tokio = { version = "1.17", optional = true }
 tower = { version = "0.4", optional = true }
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.7"
 
 [features]
 connect = ["tokio", "tower"]

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.74"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 time = { version = "0.3.7", features = ["serde", "std"] }
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.0.0", features = ["v4"] }
 os_pipe = "1.0.0"
 
 # Async dependencies

--- a/crates/runc/src/io.rs
+++ b/crates/runc/src/io.rs
@@ -19,7 +19,7 @@ use std::io::Result;
 #[cfg(not(feature = "async"))]
 use std::io::{Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::AsRawFd;
 use std::process::Stdio;
 use std::sync::Mutex;
 
@@ -253,12 +253,8 @@ pub struct NullIo {
 
 impl NullIo {
     pub fn new() -> std::io::Result<Self> {
-        let fd = nix::fcntl::open(
-            "/dev/null",
-            nix::fcntl::OFlag::O_RDONLY,
-            nix::sys::stat::Mode::empty(),
-        )?;
-        let dev_null = unsafe { Mutex::new(Some(std::fs::File::from_raw_fd(fd))) };
+        let f = OpenOptions::new().read(true).open("/dev/null")?;
+        let dev_null = Mutex::new(Some(f));
         Ok(Self { dev_null })
     }
 }

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -22,7 +22,7 @@ ttrpc-codegen = { version = "0.3.0", optional = true }
 ctrlc = { version = "3.0", features = ["termination"] }
 log = "0.4"
 simple_logger = { version = "2.0", default-features = false, features = ["stderr"] }
-tokio = { version = "1.8.0", features = ["full"] }
+tokio = { version = "1.17.0", features = ["full"] }
 
 [features]
 default = []

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -28,7 +28,7 @@ time = { version = "0.3.7", features = ["serde", "std"] }
 serde_json = "1.0.78"
 serde_derive = "1.0.136"
 serde = "1.0.136"
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.0.0", features = ["v4"] }
 signal-hook = "0.3.13"
 oci-spec = "0.5.4"
 prctl = "1.0.0"

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -313,7 +313,7 @@ async fn handle_signals(signals: Signals) {
                 match asyncify(move || {
                     Ok(wait::waitpid(
                         Some(Pid::from_raw(-1)),
-                        Some(WaitPidFlag::WNOHANG | WaitPidFlag::WUNTRACED),
+                        Some(WaitPidFlag::WNOHANG),
                     )?)
                 })
                 .await
@@ -324,10 +324,7 @@ async fn handle_signals(signals: Signals) {
                             .unwrap_or_else(|e| error!("failed to send exit event {}", e))
                     }
                     Ok(WaitStatus::Signaled(pid, sig, _)) => {
-                        warn!("child {} terminated({})", pid, sig);
-                    }
-                    Ok(WaitStatus::Stopped(pid, sig)) => {
-                        warn!("child {} stopped({})", pid, sig);
+                        debug!("child {} terminated({})", pid, sig);
                     }
                     Err(Error::Nix(Errno::ECHILD)) => {
                         break;

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use std::convert::TryFrom;
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixListener;
@@ -27,8 +28,12 @@ use std::{env, process};
 use async_trait::async_trait;
 use command_fds::{CommandFdExt, FdMapping};
 use futures::StreamExt;
-use libc::{c_int, pid_t, SIGCHLD, SIGINT, SIGPIPE, SIGTERM};
+use libc::{SIGCHLD, SIGINT, SIGPIPE, SIGTERM};
 use log::{debug, error, info, warn};
+use nix::errno::Errno;
+use nix::sys::signal::Signal;
+use nix::sys::wait::{self, WaitPidFlag, WaitStatus};
+use nix::unistd::Pid;
 use signal_hook_tokio::Signals;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Notify;
@@ -304,28 +309,42 @@ async fn handle_signals(signals: Signals) {
                 debug!("received {}", sig);
             }
             SIGCHLD => loop {
-                let result = asyncify(move || -> Result<(pid_t, c_int)> {
-                    let mut status: c_int = -1;
-                    let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
-                    if pid <= 0 {
-                        return Err(other!("wait finished"));
-                    }
-                    let status = libc::WEXITSTATUS(status);
-                    Ok((pid, status))
+                // Note: see comment at the counterpart in synchronous/mod.rs for details.
+                match asyncify(move || {
+                    Ok(wait::waitpid(
+                        Some(Pid::from_raw(-1)),
+                        Some(WaitPidFlag::WNOHANG | WaitPidFlag::WUNTRACED),
+                    )?)
                 })
-                .await;
-
-                if let Ok((res_pid, status)) = result {
-                    monitor_notify_by_pid(res_pid, status)
-                        .await
-                        .unwrap_or_else(|e| {
-                            error!("failed to send pid exit event {}", e);
-                        })
-                } else {
-                    break;
+                .await
+                {
+                    Ok(WaitStatus::Exited(pid, status)) => {
+                        monitor_notify_by_pid(pid.as_raw(), status)
+                            .await
+                            .unwrap_or_else(|e| error!("failed to send exit event {}", e))
+                    }
+                    Ok(WaitStatus::Signaled(pid, sig, _)) => {
+                        warn!("child {} terminated({})", pid, sig);
+                    }
+                    Ok(WaitStatus::Stopped(pid, sig)) => {
+                        warn!("child {} stopped({})", pid, sig);
+                    }
+                    Err(Error::Nix(Errno::ECHILD)) => {
+                        break;
+                    }
+                    Err(e) => {
+                        warn!("error occurred in signal handler: {}", e);
+                    }
+                    _ => {}
                 }
             },
-            _ => {}
+            _ => {
+                if let Ok(sig) = Signal::try_from(sig) {
+                    debug!("received {}", sig);
+                } else {
+                    warn!("received invalid signal {}", sig);
+                }
+            }
         }
     }
 }

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -325,6 +325,10 @@ async fn handle_signals(signals: Signals) {
                     }
                     Ok(WaitStatus::Signaled(pid, sig, _)) => {
                         debug!("child {} terminated({})", pid, sig);
+                        let exit_code = 128 + sig as i32;
+                        monitor_notify_by_pid(pid.as_raw(), exit_code)
+                            .await
+                            .unwrap_or_else(|e| error!("failed to send signal event {}", e))
                     }
                     Err(Error::Nix(Errno::ECHILD)) => {
                         break;

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -243,8 +243,10 @@ fn handle_signals(mut signals: Signals) {
                                 .unwrap_or_else(|e| error!("failed to send exit event {}", e))
                         }
                         Ok(WaitStatus::Signaled(pid, sig, _)) => {
-                            // TODO: add signal notification for monitor
                             debug!("child {} terminated({})", pid, sig);
+                            let exit_code = 128 + sig as i32;
+                            monitor_notify_by_pid(pid.as_raw(), exit_code)
+                                .unwrap_or_else(|e| error!("failed to send signal event {}", e))
                         }
                         Err(Errno::ECHILD) => {
                             break;

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -12,10 +12,10 @@ description = "Remote snapshotter extension for containerd"
 
 [dependencies]
 thiserror = "1.0"
-tonic = "0.6"
-prost = "0.9"
-prost-types = "0.9"
-tokio = { version = "1.15", features = ["sync"] }
+tonic = "0.7"
+prost = "0.10"
+prost-types = "0.10"
+tokio = { version = "1.17", features = ["sync"] }
 tokio-stream = "0.1.8"
 
 [dev-dependencies]
@@ -25,4 +25,4 @@ futures = "0.3.17"
 simple_logger = { version  = "2.0", default-features = false }
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.7"


### PR DESCRIPTION
removed:
- `File::from_raw_fd` in `runc::io`
- `libc::waitpid` in `shim`

Signed-off-by: Yuna Tomida <ytomida.mmm@gmail.com>