### PR TITLE
runc-shim: implement ShimExecutor in synchronous version

### DIFF
--- a/crates/runc-shim/src/asynchronous/mod.rs
+++ b/crates/runc-shim/src/asynchronous/mod.rs
@@ -101,7 +101,7 @@ impl Shim for Service {
             namespace,
             &bundle,
             &opts,
-            Some(Arc::new(ShimExecutor {})),
+            Some(Arc::new(ShimExecutor::default())),
         )?;
 
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))

--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -97,7 +97,13 @@ impl ContainerFactory<RuncContainer> for RuncFactory {
             mount_rootfs(&m, rootfs.as_path()).await?
         }
 
-        let runc = create_runc(runtime, ns, bundle, &opts, Some(Arc::new(ShimExecutor {})))?;
+        let runc = create_runc(
+            runtime,
+            ns,
+            bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
 
         let id = req.get_id();
         let stdio = Stdio::new(

--- a/crates/runc-shim/src/common.rs
+++ b/crates/runc-shim/src/common.rs
@@ -98,7 +98,7 @@ pub fn create_io(
     Ok(pio)
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct ShimExecutor {}
 
 pub fn get_spec_from_request(

--- a/crates/runc-shim/src/synchronous/service.rs
+++ b/crates/runc-shim/src/synchronous/service.rs
@@ -32,7 +32,7 @@ use shim::util::get_timestamp;
 use shim::{debug, error, io_error, other_error, warn};
 use shim::{spawn, Config, ExitSignal, Shim, StartOpts};
 
-use crate::common::{create_runc, GROUP_LABELS};
+use crate::common::{create_runc, ShimExecutor, GROUP_LABELS};
 use crate::synchronous::container::{Container, Process};
 use crate::synchronous::runc::{RuncContainer, RuncFactory};
 use crate::synchronous::task::ShimTask;
@@ -88,7 +88,13 @@ impl Shim for Service {
         let opts = read_options(&bundle)?;
         let runtime = read_runtime(&bundle)?;
 
-        let runc = create_runc(&*runtime, namespace, &bundle, &opts, None)?;
+        let runc = create_runc(
+            &*runtime,
+            namespace,
+            &bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))
             .unwrap_or_else(|e| warn!("failed to remove runc container: {}", e));
         let mut resp = DeleteResponse::new();


### PR DESCRIPTION
We still need this `ShimExecutor` wait for child processes

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>