### PR TITLE
bugfix: return a tmp dir when 'XDG_RUNTIME_DIR' was not set

### DIFF
--- a/crates/runc-shim/src/asynchronous/mod.rs
+++ b/crates/runc-shim/src/asynchronous/mod.rs
@@ -101,7 +101,7 @@ impl Shim for Service {
             namespace,
             &bundle,
             &opts,
-            Some(Arc::new(ShimExecutor {})),
+            Some(Arc::new(ShimExecutor::default())),
         )?;
 
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))

--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -97,7 +97,13 @@ impl ContainerFactory<RuncContainer> for RuncFactory {
             mount_rootfs(&m, rootfs.as_path()).await?
         }
 
-        let runc = create_runc(runtime, ns, bundle, &opts, Some(Arc::new(ShimExecutor {})))?;
+        let runc = create_runc(
+            runtime,
+            ns,
+            bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
 
         let id = req.get_id();
         let stdio = Stdio::new(

--- a/crates/runc-shim/src/common.rs
+++ b/crates/runc-shim/src/common.rs
@@ -98,7 +98,7 @@ pub fn create_io(
     Ok(pio)
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct ShimExecutor {}
 
 pub fn get_spec_from_request(

--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -44,9 +44,7 @@ use shim::protos::protobuf::well_known_types::{Any, Timestamp};
 use shim::protos::protobuf::{CodedInputStream, Message, RepeatedField};
 use shim::protos::shim::oci::ProcessDetails;
 #[cfg(not(feature = "async"))]
-use shim::util::{
-    new_temp_console_socket, read_spec_from_file, write_options, write_runtime, IntoOption,
-};
+use shim::util::{read_spec_from_file, write_options, write_runtime, IntoOption};
 use shim::Console;
 use shim::{other, other_error};
 
@@ -166,7 +164,7 @@ impl Container for RuncContainer {
                 };
                 let terminal = process.common.stdio.terminal;
                 let socket = if terminal {
-                    let s = new_temp_console_socket().map_err(other_error!(e, ""))?;
+                    let s = ConsoleSocket::new()?;
                     exec_opts.console_socket = Some(s.path.to_owned());
                     Some(s)
                 } else {
@@ -456,7 +454,7 @@ impl InitProcess {
             .no_new_keyring(self.no_new_key_ring)
             .detach(false);
         let socket = if terminal {
-            let s = new_temp_console_socket().map_err(other_error!(e, ""))?;
+            let s = ConsoleSocket::new()?;
             create_opts.console_socket = Some(s.path.to_owned());
             Some(s)
         } else {

--- a/crates/runc-shim/src/synchronous/service.rs
+++ b/crates/runc-shim/src/synchronous/service.rs
@@ -32,7 +32,7 @@ use shim::util::get_timestamp;
 use shim::{debug, error, io_error, other_error, warn};
 use shim::{spawn, Config, ExitSignal, Shim, StartOpts};
 
-use crate::common::{create_runc, GROUP_LABELS};
+use crate::common::{create_runc, ShimExecutor, GROUP_LABELS};
 use crate::synchronous::container::{Container, Process};
 use crate::synchronous::runc::{RuncContainer, RuncFactory};
 use crate::synchronous::task::ShimTask;
@@ -88,7 +88,13 @@ impl Shim for Service {
         let opts = read_options(&bundle)?;
         let runtime = read_runtime(&bundle)?;
 
-        let runc = create_runc(&*runtime, namespace, &bundle, &opts, None)?;
+        let runc = create_runc(
+            &*runtime,
+            namespace,
+            &bundle,
+            &opts,
+            Some(Arc::new(ShimExecutor::default())),
+        )?;
         runc.delete(&self.id, Some(&DeleteOpts { force: true }))
             .unwrap_or_else(|e| warn!("failed to remove runc container: {}", e));
         let mut resp = DeleteResponse::new();

--- a/crates/runc/src/utils.rs
+++ b/crates/runc/src/utils.rs
@@ -61,8 +61,8 @@ where
     path_to_string(abs_path_buf(path)?)
 }
 
-/// Fetches the value of environment variable "XDG_RUNTIME_DIR", returning a temporary directory
-/// if the variable isn't set
+/// Returns a temp dir. If the environment variable "XDG_RUNTIME_DIR" is set, return its value.
+/// Otherwise if `std::env::temp_dir()` failed, return current dir or return the temp dir depended on OS.
 fn xdg_runtime_dir() -> String {
     env::var("XDG_RUNTIME_DIR")
         .unwrap_or_else(|_| abs_string(env::temp_dir()).unwrap_or_else(|_| ".".to_string()))

--- a/crates/shim/src/asynchronous/console.rs
+++ b/crates/shim/src/asynchronous/console.rs
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 
-use std::env;
 use std::path::{Path, PathBuf};
 
 use log::warn;
@@ -22,6 +21,7 @@ use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
 use crate::asynchronous::util::mkdir;
+use crate::util::xdg_runtime_dir;
 use crate::Error;
 use crate::Result;
 
@@ -33,8 +33,7 @@ pub struct ConsoleSocket {
 
 impl ConsoleSocket {
     pub async fn new() -> Result<ConsoleSocket> {
-        let dir = env::var("XDG_RUNTIME_DIR")
-            .map(|runtime_dir| format!("{}/pty{}", runtime_dir, Uuid::new_v4(),))?;
+        let dir = format!("{}/pty{}", xdg_runtime_dir(), Uuid::new_v4());
         mkdir(&dir, 0o711).await?;
         let file_name = Path::new(&dir).join("pty.sock");
         let listener = UnixListener::bind(&file_name).map_err(io_error!(

--- a/crates/shim/src/util.rs
+++ b/crates/shim/src/util.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use std::env;
 use std::os::unix::io::RawFd;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -153,6 +154,13 @@ pub fn any(event: impl Message) -> Result<Any> {
     any.merge_from_bytes(&data)?;
 
     Ok(any)
+}
+
+/// Returns a temp dir. If the environment variable "XDG_RUNTIME_DIR" is set, return its value.
+/// Otherwise if `std::env::temp_dir()` failed, return current dir or return the temp dir depended on OS.
+pub(crate) fn xdg_runtime_dir() -> String {
+    env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| env::temp_dir().to_str().unwrap_or(".").to_string())
 }
 
 pub trait IntoOption


### PR DESCRIPTION
use a tmp dir when 'XDG_RUNTIME_DIR' was not set

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>
