### PR TITLE
Collect build timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,22 @@ jobs:
           sudo -E $(command -v cargo) test
           sudo -E $(command -v cargo) test --all-features
 
+  # Collect build timings
+  # See https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#cargo---timings
+  timings:
+    name: Timings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo build --all-features --timings
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cargo-timing
+          path: target/cargo-timings/cargo-timing.html
+          if-no-files-found: error
+
   deny:
     name: Deny
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ cargo build --release
 ```
 
 ## Minimum supported Rust version (MSRV)
-The minimum supported version of Rust is `1.54`
+Please refer to [rust-toolchain.toml](./rust-toolchain.toml) for minimum supported Rust version.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59"
+channel = "1.60"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Rust 1.60 now allows collecting build timings.
This PR updates `ci.yml` to collect a timing report.
The report will be published as an HTML artifact on Github Actions.
This information would be useful to understand how various dependencies affect build times as well as better understand how build times change over time.

More info: https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#cargo---timings

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>