### PR TITLE
Update nix dependency

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -23,7 +23,7 @@ async = ["containerd-shim/async", "runc/async", "tokio", "futures", "async-trait
 
 [dependencies]
 log = "0.4"
-nix = "0.23.1"
+nix = "0.24.1"
 libc = "0.2.95"
 time = { version = "0.3.7", features = ["serde", "std"] }
 serde = { version = "1.0.133", features = ["derive"] }

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -16,7 +16,7 @@ async = ["tokio", "async-trait", "futures", "tokio-pipe"]
 [dependencies]
 libc = "0.2.112"
 log = "0.4.14"
-nix = "0.23.1"
+nix = "0.24.1"
 oci-spec = "0.5.4"
 path-absolutize = "3.0.11"
 rand = "0.8.4"

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -21,7 +21,7 @@ go-flag = "0.1.0"
 thiserror = "1.0"
 log = { version = "0.4", features = ["std"] }
 libc = "0.2.95"
-nix = "0.23.1"
+nix = "0.24.1"
 command-fds = "0.2.1"
 lazy_static = "1.4.0"
 time = { version = "0.3.7", features = ["serde", "std"] }

--- a/crates/shim/src/util.rs
+++ b/crates/shim/src/util.rs
@@ -101,7 +101,6 @@ pub fn connect(address: impl AsRef<str>) -> Result<RawFd> {
     use nix::unistd::close;
 
     let unix_addr = UnixAddr::new(address.as_ref())?;
-    let sock_addr = SockAddr::Unix(unix_addr);
 
     // SOCK_CLOEXEC flag is Linux specific
     #[cfg(target_os = "linux")]
@@ -123,7 +122,7 @@ pub fn connect(address: impl AsRef<str>) -> Result<RawFd> {
         })?;
     }
 
-    connect(fd, &sock_addr).map_err(|e| {
+    connect(fd, &unix_addr).map_err(|e| {
         let _ = close(fd);
         e
     })?;


### PR DESCRIPTION
This updates `nix` dependency to 0.24 and removes deprecated code.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>