### PR TITLE
Run nightly CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
 
 jobs:
   checks:


### PR DESCRIPTION
Run CI every night, this will help to catch vulnerabilities from `cargo deny` earlier.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>