### PR TITLE
Add Rust fmt rules to format imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check --examples --tests --all-targets
       - run: cargo check --examples --tests --all-targets --all-features
-      - run: cargo fmt --all -- --check --files-with-diff
+
+      - run: rustup toolchain install nightly --component rustfmt
+      - run: cargo +nightly fmt --all -- --check --files-with-diff
+
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo clippy --all-targets --all-features -- -D warnings
+
       - run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings

--- a/crates/client/build.rs
+++ b/crates/client/build.rs
@@ -14,9 +14,7 @@
    limitations under the License.
 */
 
-use std::env;
-use std::fs;
-use std::io;
+use std::{env, fs, io};
 
 const PROTO_FILES: &[&str] = &[
     // Types

--- a/crates/client/examples/container.rs
+++ b/crates/client/examples/container.rs
@@ -14,24 +14,19 @@
    limitations under the License.
 */
 
+use std::{fs, fs::File};
+
+use client::{
+    services::v1::{
+        container::Runtime, containers_client::ContainersClient, tasks_client::TasksClient,
+        Container, CreateContainerRequest, CreateTaskRequest, DeleteContainerRequest,
+        DeleteTaskRequest, StartRequest, WaitRequest,
+    },
+    with_namespace,
+};
 use containerd_client as client;
-
-use client::services::v1::container::Runtime;
-use client::services::v1::containers_client::ContainersClient;
-use client::services::v1::Container;
-use client::services::v1::{CreateContainerRequest, DeleteContainerRequest};
-
-use client::services::v1::tasks_client::TasksClient;
-use client::services::v1::{CreateTaskRequest, DeleteTaskRequest, StartRequest, WaitRequest};
-
 use prost_types::Any;
-
 use tonic::Request;
-
-use std::fs;
-use std::fs::File;
-
-use client::with_namespace;
 
 const CID: &str = "abc123";
 const NAMESPACE: &str = "default";

--- a/crates/client/examples/version.rs
+++ b/crates/client/examples/version.rs
@@ -14,9 +14,8 @@
    limitations under the License.
 */
 
-use containerd_client as client;
-
 use client::services::v1::version_client::VersionClient;
+use containerd_client as client;
 
 /// Make sure you run containerd before running this example.
 #[tokio::main(flavor = "current_thread")]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -69,6 +69,7 @@ pub async fn connect(
     path: impl AsRef<std::path::Path>,
 ) -> Result<tonic::transport::Channel, tonic::transport::Error> {
     use std::convert::TryFrom;
+
     use tokio::net::UnixStream;
     use tonic::transport::Endpoint;
 

--- a/crates/logging/examples/journal.rs
+++ b/crates/logging/examples/journal.rs
@@ -14,13 +14,9 @@
    limitations under the License.
 */
 
-use std::fs;
-use std::io;
-use std::io::BufRead;
-use std::thread;
+use std::{fs, io, io::BufRead, thread};
 
 use containerd_shim_logging as logging;
-
 use logging::{Config, Driver};
 
 fn pump(reader: fs::File) {

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -23,11 +23,7 @@
 //! This crates replicates APIs provided by Go [version](https://github.com/containerd/containerd/blob/main/runtime/v2/README.md#logging).
 //!
 
-use std::env;
-use std::fmt;
-use std::fs;
-use std::os::unix::io::FromRawFd;
-use std::process;
+use std::{env, fmt, fs, os::unix::io::FromRawFd, process};
 
 /// Logging binary configuration received from containerd.
 #[derive(Debug)]

--- a/crates/runc-shim/src/common.rs
+++ b/crates/runc-shim/src/common.rs
@@ -14,25 +14,29 @@
    limitations under the License.
 */
 
-use std::io::IoSliceMut;
-use std::ops::Deref;
-use std::os::unix::io::RawFd;
-use std::path::Path;
-use std::sync::Arc;
+use std::{io::IoSliceMut, ops::Deref, os::unix::io::RawFd, path::Path, sync::Arc};
 
+use containerd_shim::{
+    api::{ExecProcessRequest, Options},
+    io::Stdio,
+    io_error, other, other_error,
+    util::IntoOption,
+    Error,
+};
 use log::{debug, warn};
-use nix::cmsg_space;
-use nix::sys::socket::{recvmsg, ControlMessageOwned, MsgFlags, UnixAddr};
-use nix::sys::termios::tcgetattr;
+use nix::{
+    cmsg_space,
+    sys::{
+        socket::{recvmsg, ControlMessageOwned, MsgFlags, UnixAddr},
+        termios::tcgetattr,
+    },
+};
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
-
-use containerd_shim::api::{ExecProcessRequest, Options};
-use containerd_shim::io::Stdio;
-use containerd_shim::util::IntoOption;
-use containerd_shim::{io_error, other, other_error, Error};
-use runc::io::{Io, NullIo, FIFO};
-use runc::options::GlobalOpts;
-use runc::{Runc, Spawner};
+use runc::{
+    io::{Io, NullIo, FIFO},
+    options::GlobalOpts,
+    Runc, Spawner,
+};
 
 pub const GROUP_LABELS: [&str; 2] = [
     "io.containerd.runc.v2.group",

--- a/crates/runc-shim/src/synchronous/container.rs
+++ b/crates/runc-shim/src/synchronous/container.rs
@@ -14,31 +14,34 @@
    limitations under the License.
 */
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::fs::{File, OpenOptions};
-use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::path::Path;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-
-use log::debug;
-use oci_spec::runtime::LinuxResources;
-use time::OffsetDateTime;
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    fs::{File, OpenOptions},
+    os::unix::io::{AsRawFd, FromRawFd},
+    path::Path,
+    sync::mpsc::{sync_channel, Receiver, SyncSender},
+};
 
 use containerd_shim as shim;
-use shim::api::*;
-use shim::console::ConsoleSocket;
-use shim::error::{Error, Result};
-use shim::io::Stdio;
-use shim::ioctl_set_winsz;
-use shim::protos::cgroups::metrics::Metrics;
-use shim::util::{convert_to_timestamp, read_pid_from_file};
-use shim::Console;
-use shim::{io_error, other, other_error};
+use log::debug;
+use oci_spec::runtime::LinuxResources;
+use shim::{
+    api::*,
+    console::ConsoleSocket,
+    error::{Error, Result},
+    io::Stdio,
+    io_error, ioctl_set_winsz, other, other_error,
+    protos::cgroups::metrics::Metrics,
+    util::{convert_to_timestamp, read_pid_from_file},
+    Console,
+};
+use time::OffsetDateTime;
 
-use crate::common::receive_socket;
-use crate::common::ProcessIO;
-use crate::synchronous::io::spawn_copy_for_tty;
+use crate::{
+    common::{receive_socket, ProcessIO},
+    synchronous::io::spawn_copy_for_tty,
+};
 
 pub trait ContainerFactory<C> {
     fn create(&self, ns: &str, req: &CreateTaskRequest) -> Result<C>;

--- a/crates/runc-shim/src/synchronous/io.rs
+++ b/crates/runc-shim/src/synchronous/io.rs
@@ -14,18 +14,19 @@
    limitations under the License.
 */
 
-use std::fs::OpenOptions;
-use std::io::{ErrorKind, Read, Write};
-use std::thread::JoinHandle;
+use std::{
+    fs::OpenOptions,
+    io::{ErrorKind, Read, Write},
+    thread::JoinHandle,
+};
 
-use crossbeam::sync::WaitGroup;
-use log::debug;
-
-use containerd_shim::io::Stdio;
 use containerd_shim::{
     error::{Error, Result},
+    io::Stdio,
     io_error,
 };
+use crossbeam::sync::WaitGroup;
+use log::debug;
 
 use crate::common::ProcessIO;
 

--- a/crates/runc-shim/src/synchronous/task.rs
+++ b/crates/runc-shim/src/synchronous/task.rs
@@ -14,24 +14,26 @@
    limitations under the License.
 */
 
-use std::collections::HashMap;
-use std::process;
-use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex, Once};
-
-use log::{debug, info, warn};
-use oci_spec::runtime::LinuxResources;
+use std::{
+    collections::HashMap,
+    process,
+    sync::{mpsc::Sender, Arc, Mutex, Once},
+};
 
 use containerd_shim as shim;
-
-use shim::api::*;
-use shim::event::Event;
-use shim::protos::events::task::{
-    TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskIO, TaskStart,
+use log::{debug, info, warn};
+use oci_spec::runtime::LinuxResources;
+use shim::{
+    api::*,
+    event::Event,
+    other_error,
+    protos::{
+        events::task::{TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskIO, TaskStart},
+        protobuf::MessageDyn,
+    },
+    util::{convert_to_any, convert_to_timestamp, IntoOption},
+    Error, ExitSignal, Task, TtrpcContext, TtrpcResult,
 };
-use shim::protos::protobuf::MessageDyn;
-use shim::util::{convert_to_any, convert_to_timestamp, IntoOption};
-use shim::{other_error, Error, ExitSignal, Task, TtrpcContext, TtrpcResult};
 
 use crate::synchronous::container::{Container, ContainerFactory};
 

--- a/crates/runc/src/container.rs
+++ b/crates/runc/src/container.rs
@@ -36,8 +36,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use time::serde::timestamp;
-use time::OffsetDateTime;
+use time::{serde::timestamp, OffsetDateTime};
 
 /// Information for runc container
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/runc/src/error.rs
+++ b/crates/runc/src/error.rs
@@ -33,9 +33,7 @@
  * limitations under the License.
  */
 
-use std::env;
-use std::io;
-use std::process::ExitStatus;
+use std::{env, io, process::ExitStatus};
 
 use thiserror::Error;
 

--- a/crates/runc/src/io.rs
+++ b/crates/runc/src/io.rs
@@ -13,15 +13,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-use std::fmt::Debug;
-use std::fs::{File, OpenOptions};
-use std::io::Result;
 #[cfg(not(feature = "async"))]
 use std::io::{Read, Write};
-use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::AsRawFd;
-use std::process::Stdio;
-use std::sync::Mutex;
+use std::{
+    fmt::Debug,
+    fs::{File, OpenOptions},
+    io::Result,
+    os::unix::{fs::OpenOptionsExt, io::AsRawFd},
+    process::Stdio,
+    sync::Mutex,
+};
 
 use log::debug;
 use nix::unistd::{Gid, Uid};

--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -35,10 +35,12 @@
 
 //! A crate for consuming the runc binary in your Rust applications, similar to
 //! [go-runc](https://github.com/containerd/go-runc) for Go.
-use std::fmt::{self, Debug, Display};
-use std::path::{Path, PathBuf};
-use std::process::{ExitStatus, Stdio};
-use std::sync::Arc;
+use std::{
+    fmt::{self, Debug, Display},
+    path::{Path, PathBuf},
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+};
 
 #[cfg(feature = "async")]
 use async_trait::async_trait;
@@ -46,10 +48,7 @@ use async_trait::async_trait;
 use log::debug;
 use oci_spec::runtime::{LinuxResources, Process};
 
-use crate::container::Container;
-use crate::error::Error;
-use crate::options::*;
-use crate::utils::write_value_to_temp_file;
+use crate::{container::Container, error::Error, options::*, utils::write_value_to_temp_file};
 
 pub mod container;
 pub mod error;
@@ -603,8 +602,10 @@ impl Runc {
 mod tests {
     use std::sync::Arc;
 
-    use super::io::{InheritedStdIo, PipedStdIo};
-    use super::*;
+    use super::{
+        io::{InheritedStdIo, PipedStdIo},
+        *,
+    };
 
     fn ok_client() -> Runc {
         GlobalOpts::new()
@@ -786,8 +787,10 @@ mod tests {
 mod tests {
     use std::sync::Arc;
 
-    use super::io::{InheritedStdIo, PipedStdIo};
-    use super::*;
+    use super::{
+        io::{InheritedStdIo, PipedStdIo},
+        *,
+    };
 
     fn ok_client() -> Runc {
         GlobalOpts::new()

--- a/crates/runc/src/monitor.rs
+++ b/crates/runc/src/monitor.rs
@@ -19,8 +19,10 @@ use std::process::{ExitStatus, Output};
 use async_trait::async_trait;
 use log::error;
 use time::OffsetDateTime;
-use tokio::process::Command;
-use tokio::sync::oneshot::{channel, Receiver, Sender};
+use tokio::{
+    process::Command,
+    sync::oneshot::{channel, Receiver, Sender},
+};
 
 use crate::error::Error;
 
@@ -132,8 +134,7 @@ pub async fn execute<T: ProcessMonitor + Send + Sync>(
 mod tests {
     use std::process::Stdio;
 
-    use tokio::process::Command;
-    use tokio::sync::oneshot::channel;
+    use tokio::{process::Command, sync::oneshot::channel};
 
     use super::*;
 

--- a/crates/runc/src/options.rs
+++ b/crates/runc/src/options.rs
@@ -33,14 +33,13 @@
  * limitations under the License.
  */
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
-use crate::error::Error;
-use crate::io::Io;
-use crate::{utils, DefaultExecutor, Spawner};
-use crate::{LogFormat, Runc};
+use crate::{error::Error, io::Io, utils, DefaultExecutor, LogFormat, Runc, Spawner};
 
 // constants for log format
 pub const JSON: &str = "json";

--- a/crates/runc/src/utils.rs
+++ b/crates/runc/src/utils.rs
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
-use std::env;
 #[cfg(not(feature = "async"))]
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use path_absolutize::*;
 use serde::Serialize;

--- a/crates/shim-protos/build.rs
+++ b/crates/shim-protos/build.rs
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
 
 use ttrpc_codegen::{Codegen, Customize, ProtobufCustomize};
 

--- a/crates/shim-protos/examples/connect-async.rs
+++ b/crates/shim-protos/examples/connect-async.rs
@@ -16,12 +16,9 @@
 
 use std::env;
 
+use client::{api, shim::shim_ttrpc_async::TaskClient};
 use containerd_shim_protos as client;
-
-use client::api;
-use client::shim::shim_ttrpc_async::TaskClient;
-use ttrpc::asynchronous::Client;
-use ttrpc::context::Context;
+use ttrpc::{asynchronous::Client, context::Context};
 
 #[tokio::main]
 async fn main() {

--- a/crates/shim-protos/examples/connect.rs
+++ b/crates/shim-protos/examples/connect.rs
@@ -16,9 +16,8 @@
 
 use std::env;
 
-use containerd_shim_protos as client;
-
 use client::api;
+use containerd_shim_protos as client;
 use ttrpc::context::Context;
 
 fn main() {

--- a/crates/shim-protos/examples/ttrpc-client-async.rs
+++ b/crates/shim-protos/examples/ttrpc-client-async.rs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use containerd_shim_protos::api::CreateTaskRequest;
-use containerd_shim_protos::shim::shim_ttrpc_async::TaskClient;
-use ttrpc::asynchronous::Client;
-use ttrpc::context::{self, Context};
+use containerd_shim_protos::{api::CreateTaskRequest, shim::shim_ttrpc_async::TaskClient};
+use ttrpc::{
+    asynchronous::Client,
+    context::{self, Context},
+};
 
 fn default_ctx() -> Context {
     let mut ctx = context::with_timeout(0);

--- a/crates/shim-protos/examples/ttrpc-client.rs
+++ b/crates/shim-protos/examples/ttrpc-client.rs
@@ -14,9 +14,10 @@
 // limitations under the License.
 
 use containerd_shim_protos::{api::CreateTaskRequest, TaskClient};
-
-use ttrpc::context::{self, Context};
-use ttrpc::Client;
+use ttrpc::{
+    context::{self, Context},
+    Client,
+};
 
 fn main() {
     let c = Client::connect("unix:///tmp/shim-proto-ttrpc-001").unwrap();

--- a/crates/shim-protos/examples/ttrpc-server-async.rs
+++ b/crates/shim-protos/examples/ttrpc-server-async.rs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-use std::thread;
+use std::{sync::Arc, thread};
 
 use async_trait::async_trait;
-use containerd_shim_protos::api::{CreateTaskRequest, CreateTaskResponse};
-use containerd_shim_protos::shim::shim_ttrpc_async::{create_task, Task};
+use containerd_shim_protos::{
+    api::{CreateTaskRequest, CreateTaskResponse},
+    shim::shim_ttrpc_async::{create_task, Task},
+};
 use ttrpc::asynchronous::Server;
 
 #[derive(Debug, PartialEq)]

--- a/crates/shim-protos/examples/ttrpc-server.rs
+++ b/crates/shim-protos/examples/ttrpc-server.rs
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-use std::thread;
+use std::{sync::Arc, thread};
 
 use containerd_shim_protos::{
     api::{CreateTaskRequest, CreateTaskResponse},

--- a/crates/shim-protos/src/lib.rs
+++ b/crates/shim-protos/src/lib.rs
@@ -77,11 +77,10 @@ pub mod shim_sync {
     /// TTRPC client reexport for easier access.
     pub use ttrpc::Client;
 
-    /// Shim task service.
-    pub use crate::shim::shim_ttrpc::{create_task, Task, TaskClient};
-
     /// Shim events service.
     pub use crate::shim::events_ttrpc::{create_events, Events, EventsClient};
+    /// Shim task service.
+    pub use crate::shim::shim_ttrpc::{create_task, Task, TaskClient};
 }
 
 pub use shim_sync::*;
@@ -91,18 +90,13 @@ pub mod shim_async {
     /// TTRPC client reexport for easier access.
     pub use ttrpc::asynchronous::Client;
 
-    /// Shim task service.
-    pub use crate::shim::shim_ttrpc_async::{create_task, Task, TaskClient};
-
     /// Shim events service.
     pub use crate::shim::events_ttrpc_async::{create_events, Events, EventsClient};
+    /// Shim task service.
+    pub use crate::shim::shim_ttrpc_async::{create_task, Task, TaskClient};
 }
 
 /// Reexport auto-generated public data structures.
 pub mod api {
-    pub use crate::shim::empty::*;
-    pub use crate::shim::events::*;
-    pub use crate::shim::mount::*;
-    pub use crate::shim::shim::*;
-    pub use crate::shim::task::*;
+    pub use crate::shim::{empty::*, events::*, mount::*, shim::*, task::*};
 }

--- a/crates/shim-protos/src/shim.rs
+++ b/crates/shim-protos/src/shim.rs
@@ -64,8 +64,7 @@ mod gogo {
     pub use crate::types::gogo::*;
 }
 
-/// Shim task service.
-pub use shim_ttrpc::{create_task, Task, TaskClient};
-
 /// Shim events service.
 pub use events_ttrpc::{create_events, Events, EventsClient};
+/// Shim task service.
+pub use shim_ttrpc::{create_task, Task, TaskClient};

--- a/crates/shim-protos/tests/ttrpc.rs
+++ b/crates/shim-protos/tests/ttrpc.rs
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::collections::HashMap;
-use std::sync::mpsc::channel;
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{mpsc::channel, Arc},
+};
 
-use containerd_shim_protos::api::{CreateTaskRequest, CreateTaskResponse, DeleteRequest};
-use containerd_shim_protos::shim::shim_ttrpc::create_task;
-use containerd_shim_protos::Task;
+use containerd_shim_protos::{
+    api::{CreateTaskRequest, CreateTaskResponse, DeleteRequest},
+    shim::shim_ttrpc::create_task,
+    Task,
+};
 use protobuf::{CodedInputStream, CodedOutputStream, Message};
 use ttrpc::{Code, MessageHeader, Request, Response, TtrpcContext};
 

--- a/crates/shim/examples/publish.rs
+++ b/crates/shim/examples/publish.rs
@@ -15,8 +15,7 @@
 */
 use std::env;
 
-use containerd_shim::publisher::RemotePublisher;
-use containerd_shim::Context;
+use containerd_shim::{publisher::RemotePublisher, Context};
 use containerd_shim_protos::events::task::TaskOOM;
 
 #[cfg(not(feature = "async"))]

--- a/crates/shim/examples/skeleton.rs
+++ b/crates/shim/examples/skeleton.rs
@@ -20,11 +20,12 @@ use containerd_shim as shim;
 mod skeleton {
     use std::sync::Arc;
 
-    use log::info;
-
     use containerd_shim as shim;
-    use shim::synchronous::publisher::RemotePublisher;
-    use shim::{api, Config, DeleteResponse, ExitSignal, TtrpcContext, TtrpcResult};
+    use log::info;
+    use shim::{
+        api, synchronous::publisher::RemotePublisher, Config, DeleteResponse, ExitSignal,
+        TtrpcContext, TtrpcResult,
+    };
 
     #[derive(Clone)]
     pub(crate) struct Service {

--- a/crates/shim/examples/skeleton_async.rs
+++ b/crates/shim/examples/skeleton_async.rs
@@ -17,15 +17,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use containerd_shim::{
+    asynchronous::{run, spawn, ExitSignal, Shim},
+    publisher::RemotePublisher,
+    Config, Error, StartOpts, TtrpcResult,
+};
+use containerd_shim_protos::{
+    api, api::DeleteResponse, shim_async::Task, ttrpc::r#async::TtrpcContext,
+};
 use log::info;
-
-use containerd_shim::asynchronous::{run, spawn, ExitSignal, Shim};
-use containerd_shim::publisher::RemotePublisher;
-use containerd_shim::{Config, Error, StartOpts, TtrpcResult};
-use containerd_shim_protos::api;
-use containerd_shim_protos::api::DeleteResponse;
-use containerd_shim_protos::shim_async::Task;
-use containerd_shim_protos::ttrpc::r#async::TtrpcContext;
 
 #[derive(Clone)]
 struct Service {

--- a/crates/shim/src/asynchronous/console.rs
+++ b/crates/shim/src/asynchronous/console.rs
@@ -20,9 +20,10 @@ use log::warn;
 use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
-use crate::util::{mkdir, xdg_runtime_dir};
-use crate::Error;
-use crate::Result;
+use crate::{
+    util::{mkdir, xdg_runtime_dir},
+    Error, Result,
+};
 
 pub struct ConsoleSocket {
     pub listener: UnixListener,

--- a/crates/shim/src/asynchronous/container.rs
+++ b/crates/shim/src/asynchronous/container.rs
@@ -17,19 +17,16 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use containerd_shim_protos::{
+    api::{CreateTaskRequest, ExecProcessRequest, ProcessInfo, StateResponse},
+    cgroups::metrics::Metrics,
+};
 use log::debug;
 use oci_spec::runtime::LinuxResources;
 use time::OffsetDateTime;
 use tokio::sync::oneshot::Receiver;
 
-use containerd_shim_protos::api::{
-    CreateTaskRequest, ExecProcessRequest, ProcessInfo, StateResponse,
-};
-use containerd_shim_protos::cgroups::metrics::Metrics;
-
-use crate::asynchronous::processes::Process;
-use crate::error::Result;
-use crate::Error;
+use crate::{asynchronous::processes::Process, error::Result, Error};
 
 #[async_trait]
 pub trait Container {

--- a/crates/shim/src/asynchronous/monitor.rs
+++ b/crates/shim/src/asynchronous/monitor.rs
@@ -18,12 +18,15 @@ use std::collections::HashMap;
 
 use lazy_static::lazy_static;
 use log::error;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::sync::Mutex;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    Mutex,
+};
 
-use crate::error::Error;
-use crate::error::Result;
-use crate::monitor::{ExitEvent, Subject, Topic};
+use crate::{
+    error::{Error, Result},
+    monitor::{ExitEvent, Subject, Topic},
+};
 
 lazy_static! {
     pub static ref MONITOR: Mutex<Monitor> = {
@@ -143,10 +146,12 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
-    use crate::asynchronous::monitor::{
-        monitor_notify_by_exec, monitor_notify_by_pid, monitor_subscribe, monitor_unsubscribe,
+    use crate::{
+        asynchronous::monitor::{
+            monitor_notify_by_exec, monitor_notify_by_pid, monitor_subscribe, monitor_unsubscribe,
+        },
+        monitor::{ExitEvent, Subject, Topic},
     };
-    use crate::monitor::{ExitEvent, Subject, Topic};
 
     #[tokio::test]
     async fn test_monitor() {

--- a/crates/shim/src/asynchronous/processes.rs
+++ b/crates/shim/src/asynchronous/processes.rs
@@ -14,21 +14,19 @@
    limitations under the License.
 */
 
-use std::os::unix::io::AsRawFd;
-use std::sync::Arc;
+use std::{os::unix::io::AsRawFd, sync::Arc};
 
 use async_trait::async_trait;
+use containerd_shim_protos::{
+    api::{ProcessInfo, StateResponse, Status},
+    cgroups::metrics::Metrics,
+    protobuf::well_known_types::timestamp::Timestamp,
+};
 use oci_spec::runtime::LinuxResources;
 use time::OffsetDateTime;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 
-use containerd_shim_protos::api::{ProcessInfo, StateResponse, Status};
-use containerd_shim_protos::cgroups::metrics::Metrics;
-use containerd_shim_protos::protobuf::well_known_types::timestamp::Timestamp;
-
-use crate::io::Stdio;
-use crate::util::asyncify;
-use crate::{ioctl_set_winsz, Console};
+use crate::{io::Stdio, ioctl_set_winsz, util::asyncify, Console};
 
 #[async_trait]
 pub trait Process {

--- a/crates/shim/src/asynchronous/publisher.rs
+++ b/crates/shim/src/asynchronous/publisher.rs
@@ -17,18 +17,19 @@
 use std::os::unix::io::RawFd;
 
 use async_trait::async_trait;
+use containerd_shim_protos::{
+    api::Empty,
+    protobuf::MessageDyn,
+    shim::events,
+    shim_async::{Client, Events, EventsClient},
+    ttrpc,
+    ttrpc::{context::Context, r#async::TtrpcContext},
+};
 
-use containerd_shim_protos::api::Empty;
-use containerd_shim_protos::protobuf::MessageDyn;
-use containerd_shim_protos::shim::events;
-use containerd_shim_protos::shim_async::{Client, Events, EventsClient};
-use containerd_shim_protos::ttrpc;
-use containerd_shim_protos::ttrpc::context::Context;
-use containerd_shim_protos::ttrpc::r#async::TtrpcContext;
-
-use crate::error::Result;
-use crate::util::asyncify;
-use crate::util::{connect, convert_to_any, timestamp};
+use crate::{
+    error::Result,
+    util::{asyncify, connect, convert_to_any, timestamp},
+};
 
 /// Async Remote publisher connects to containerd's TTRPC endpoint to publish events from shim.
 pub struct RemotePublisher {
@@ -97,17 +98,21 @@ impl Events for RemotePublisher {
 
 #[cfg(test)]
 mod tests {
-    use std::os::unix::io::AsRawFd;
-    use std::os::unix::net::UnixListener;
-    use std::sync::Arc;
+    use std::{
+        os::unix::{io::AsRawFd, net::UnixListener},
+        sync::Arc,
+    };
 
-    use tokio::sync::mpsc::{channel, Sender};
-    use tokio::sync::Barrier;
-
-    use containerd_shim_protos::api::{Empty, ForwardRequest};
-    use containerd_shim_protos::events::task::TaskOOM;
-    use containerd_shim_protos::shim_async::create_events;
-    use containerd_shim_protos::ttrpc::asynchronous::Server;
+    use containerd_shim_protos::{
+        api::{Empty, ForwardRequest},
+        events::task::TaskOOM,
+        shim_async::create_events,
+        ttrpc::asynchronous::Server,
+    };
+    use tokio::sync::{
+        mpsc::{channel, Sender},
+        Barrier,
+    };
 
     use super::*;
 

--- a/crates/shim/src/asynchronous/util.rs
+++ b/crates/shim/src/asynchronous/util.rs
@@ -16,19 +16,20 @@
 
 use std::path::Path;
 
+use containerd_shim_protos::{api::Mount, shim::oci::Options};
 use libc::mode_t;
 use nix::sys::stat::Mode;
 use oci_spec::runtime::Spec;
-use tokio::fs::OpenOptions;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::task::spawn_blocking;
+use tokio::{
+    fs::OpenOptions,
+    io::{AsyncReadExt, AsyncWriteExt},
+    task::spawn_blocking,
+};
 
-use containerd_shim_protos::api::Mount;
-use containerd_shim_protos::shim::oci::Options;
-
-use crate::error::Error;
-use crate::error::Result;
-use crate::util::{AsOption, JsonOptions, CONFIG_FILE_NAME, OPTIONS_FILE_NAME, RUNTIME_FILE_NAME};
+use crate::{
+    error::{Error, Result},
+    util::{AsOption, JsonOptions, CONFIG_FILE_NAME, OPTIONS_FILE_NAME, RUNTIME_FILE_NAME},
+};
 
 pub async fn asyncify<F, T>(f: F) -> Result<T>
 where

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -16,20 +16,17 @@
 
 #![cfg(target_os = "linux")]
 
-use std::fs;
-use std::io::Read;
-use std::path::Path;
+use std::{fs, io::Read, path::Path};
 
-use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
-use cgroups_rs::{hierarchies, Cgroup, CgroupPid, MaxValue, Subsystem};
-use oci_spec::runtime::LinuxResources;
-
-use containerd_shim_protos::cgroups::metrics::{
-    CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics,
+use cgroups_rs::{
+    cgroup::get_cgroups_relative_paths_by_pid, hierarchies, Cgroup, CgroupPid, MaxValue, Subsystem,
 };
-use containerd_shim_protos::protobuf::well_known_types::any::Any;
-use containerd_shim_protos::protobuf::Message;
-use containerd_shim_protos::shim::oci::Options;
+use containerd_shim_protos::{
+    cgroups::metrics::{CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics},
+    protobuf::{well_known_types::any::Any, Message},
+    shim::oci::Options,
+};
+use oci_spec::runtime::LinuxResources;
 
 use crate::error::{Error, Result};
 

--- a/crates/shim/src/error.rs
+++ b/crates/shim/src/error.rs
@@ -16,8 +16,10 @@
 
 use thiserror::Error;
 
-use crate::monitor::ExitEvent;
-use crate::protos::{protobuf, ttrpc};
+use crate::{
+    monitor::ExitEvent,
+    protos::{protobuf, ttrpc},
+};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/crates/shim/src/event.rs
+++ b/crates/shim/src/event.rs
@@ -1,5 +1,4 @@
-use containerd_shim_protos::events::task::*;
-use containerd_shim_protos::protobuf::MessageDyn;
+use containerd_shim_protos::{events::task::*, protobuf::MessageDyn};
 
 pub trait Event: MessageDyn {
     fn topic(&self) -> String;

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -32,18 +32,20 @@
 //! ```
 //!
 
-use std::collections::hash_map::DefaultHasher;
-use std::fs::File;
-use std::hash::Hasher;
-use std::os::unix::io::RawFd;
-use std::os::unix::net::UnixListener;
-use std::path::{Path, PathBuf};
-
-use nix::ioctl_write_ptr_bad;
+use std::{
+    collections::hash_map::DefaultHasher,
+    fs::File,
+    hash::Hasher,
+    os::unix::{io::RawFd, net::UnixListener},
+    path::{Path, PathBuf},
+};
 
 pub use containerd_shim_protos as protos;
-pub use protos::shim::shim::DeleteResponse;
-pub use protos::ttrpc::{context::Context, Result as TtrpcResult};
+use nix::ioctl_write_ptr_bad;
+pub use protos::{
+    shim::shim::DeleteResponse,
+    ttrpc::{context::Context, Result as TtrpcResult},
+};
 
 #[cfg(feature = "async")]
 pub use crate::asynchronous::*;
@@ -70,10 +72,11 @@ pub mod util;
 
 /// Generated request/response structures.
 pub mod api {
-    pub use super::protos::api::Status;
-    pub use super::protos::shim::oci::Options;
-    pub use super::protos::shim::shim::*;
-    pub use super::protos::types::empty::Empty;
+    pub use super::protos::{
+        api::Status,
+        shim::{oci::Options, shim::*},
+        types::empty::Empty,
+    };
 }
 
 macro_rules! cfg_not_async {

--- a/crates/shim/src/logger.rs
+++ b/crates/shim/src/logger.rs
@@ -14,12 +14,14 @@
    limitations under the License.
 */
 
-use std::borrow::BorrowMut;
-use std::fs::{File, OpenOptions};
-use std::io;
-use std::io::Write;
-use std::path::Path;
-use std::sync::Mutex;
+use std::{
+    borrow::BorrowMut,
+    fs::{File, OpenOptions},
+    io,
+    io::Write,
+    path::Path,
+    sync::Mutex,
+};
 
 use log::{Metadata, Record};
 

--- a/crates/shim/src/mount.rs
+++ b/crates/shim/src/mount.rs
@@ -15,10 +15,12 @@
 */
 #![allow(unused)]
 
-use std::collections::HashMap;
-use std::env;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    env,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not},
+    path::Path,
+};
 
 use lazy_static::lazy_static;
 use log::error;

--- a/crates/shim/src/synchronous/console.rs
+++ b/crates/shim/src/synchronous/console.rs
@@ -14,15 +14,18 @@
    limitations under the License.
 */
 
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::{Path, PathBuf};
+use std::{
+    os::unix::net::{UnixListener, UnixStream},
+    path::{Path, PathBuf},
+};
 
 use log::warn;
 use uuid::Uuid;
 
-use crate::util::{mkdir, xdg_runtime_dir};
-use crate::Error;
-use crate::Result;
+use crate::{
+    util::{mkdir, xdg_runtime_dir},
+    Error, Result,
+};
 
 pub struct ConsoleSocket {
     pub listener: UnixListener,

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -32,35 +32,42 @@
 //! ```
 //!
 
-use std::convert::TryFrom;
-use std::env;
-use std::fs;
-use std::io::Write;
-use std::os::unix::fs::FileTypeExt;
-use std::os::unix::io::AsRawFd;
-use std::path::Path;
-use std::process::{self, Command, Stdio};
-use std::sync::{Arc, Condvar, Mutex};
+use std::{
+    convert::TryFrom,
+    env, fs,
+    io::Write,
+    os::unix::{fs::FileTypeExt, io::AsRawFd},
+    path::Path,
+    process::{self, Command, Stdio},
+    sync::{Arc, Condvar, Mutex},
+};
 
 use command_fds::{CommandFdExt, FdMapping};
 use libc::{SIGCHLD, SIGINT, SIGPIPE, SIGTERM};
 pub use log::{debug, error, info, warn};
-use nix::errno::Errno;
-use nix::sys::signal::Signal;
-use nix::sys::wait::{self, WaitPidFlag, WaitStatus};
-use nix::unistd::Pid;
+use nix::{
+    errno::Errno,
+    sys::{
+        signal::Signal,
+        wait::{self, WaitPidFlag, WaitStatus},
+    },
+    unistd::Pid,
+};
 use signal_hook::iterator::Signals;
-
-use crate::protos::protobuf::Message;
-use crate::protos::shim::shim_ttrpc::{create_task, Task};
-use crate::protos::ttrpc::{Client, Server};
 use util::{read_address, write_address};
 
-use crate::api::DeleteResponse;
-use crate::synchronous::publisher::RemotePublisher;
-use crate::Error;
-use crate::{args, logger, reap, Result, TTRPC_ADDRESS};
-use crate::{parse_sockaddr, socket_address, start_listener, Config, StartOpts, SOCKET_FD};
+use crate::{
+    api::DeleteResponse,
+    args, logger, parse_sockaddr,
+    protos::{
+        protobuf::Message,
+        shim::shim_ttrpc::{create_task, Task},
+        ttrpc::{Client, Server},
+    },
+    reap, socket_address, start_listener,
+    synchronous::publisher::RemotePublisher,
+    Config, Error, Result, StartOpts, SOCKET_FD, TTRPC_ADDRESS,
+};
 
 pub mod monitor;
 pub mod publisher;

--- a/crates/shim/src/synchronous/monitor.rs
+++ b/crates/shim/src/synchronous/monitor.rs
@@ -14,15 +14,21 @@
    limitations under the License.
 */
 
-use std::collections::HashMap;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Mutex;
+use std::{
+    collections::HashMap,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Mutex,
+    },
+};
 
 use lazy_static::lazy_static;
 use log::{error, warn};
 
-use crate::monitor::{ExitEvent, Subject, Topic};
-use crate::Result;
+use crate::{
+    monitor::{ExitEvent, Subject, Topic},
+    Result,
+};
 
 lazy_static! {
     pub static ref MONITOR: Mutex<Monitor> = {

--- a/crates/shim/src/synchronous/publisher.rs
+++ b/crates/shim/src/synchronous/publisher.rs
@@ -16,16 +16,19 @@
 
 //! Implements a client to publish events from the shim back to containerd.
 
+use client::{
+    protobuf::MessageDyn,
+    shim::events,
+    ttrpc::{self, context::Context},
+    types::empty,
+    Client, Events, EventsClient,
+};
 use containerd_shim_protos as client;
 
-use client::protobuf::MessageDyn;
-use client::shim::events;
-use client::ttrpc::{self, context::Context};
-use client::types::empty;
-use client::{Client, Events, EventsClient};
-
-use crate::error::Result;
-use crate::util::{connect, convert_to_any, timestamp};
+use crate::{
+    error::Result,
+    util::{connect, convert_to_any, timestamp},
+};
 
 /// Remote publisher connects to containerd's TTRPC endpoint to publish events from shim.
 pub struct RemotePublisher {
@@ -87,14 +90,16 @@ impl Events for RemotePublisher {
 
 #[cfg(test)]
 mod tests {
-    use std::os::unix::io::AsRawFd;
-    use std::os::unix::net::UnixListener;
-    use std::sync::{Arc, Barrier};
+    use std::{
+        os::unix::{io::AsRawFd, net::UnixListener},
+        sync::{Arc, Barrier},
+    };
 
+    use client::{
+        api::{Empty, ForwardRequest},
+        events::task::TaskOOM,
+    };
     use ttrpc::Server;
-
-    use client::api::{Empty, ForwardRequest};
-    use client::events::task::TaskOOM;
 
     use super::*;
 

--- a/crates/shim/src/synchronous/util.rs
+++ b/crates/shim/src/synchronous/util.rs
@@ -14,19 +14,22 @@
    limitations under the License.
 */
 
-use std::fs::{rename, File, OpenOptions};
-use std::io::{Read, Write};
-use std::path::Path;
+use std::{
+    fs::{rename, File, OpenOptions},
+    io::{Read, Write},
+    path::Path,
+};
 
+use containerd_shim_protos::shim::oci::Options;
 use libc::mode_t;
 use log::warn;
 use nix::sys::stat::Mode;
 use oci_spec::runtime::Spec;
 
-use containerd_shim_protos::shim::oci::Options;
-
-use crate::util::{JsonOptions, OPTIONS_FILE_NAME, RUNTIME_FILE_NAME};
-use crate::Error;
+use crate::{
+    util::{JsonOptions, OPTIONS_FILE_NAME, RUNTIME_FILE_NAME},
+    Error,
+};
 
 pub fn read_file_to_str<P: AsRef<Path>>(filename: P) -> crate::Result<String> {
     let mut file = File::open(&filename).map_err(io_error!(

--- a/crates/shim/src/util.rs
+++ b/crates/shim/src/util.rs
@@ -14,21 +14,27 @@
    limitations under the License.
 */
 
-use std::env;
-use std::os::unix::io::RawFd;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    env,
+    os::unix::io::RawFd,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use crate::api::Options;
 #[cfg(feature = "async")]
 pub use crate::asynchronous::util::*;
-use crate::error::Result;
-use crate::protos::protobuf::well_known_types::{any::Any, timestamp::Timestamp};
-use crate::protos::protobuf::MessageDyn;
 #[cfg(not(feature = "async"))]
 pub use crate::synchronous::util::*;
+use crate::{
+    api::Options,
+    error::Result,
+    protos::protobuf::{
+        well_known_types::{any::Any, timestamp::Timestamp},
+        MessageDyn,
+    },
+};
 
 pub const CONFIG_FILE_NAME: &str = "config.json";
 pub const OPTIONS_FILE_NAME: &str = "options.json";
@@ -96,8 +102,7 @@ impl From<JsonOptions> for Options {
 }
 
 pub fn connect(address: impl AsRef<str>) -> Result<RawFd> {
-    use nix::sys::socket::*;
-    use nix::unistd::close;
+    use nix::{sys::socket::*, unistd::close};
 
     let unix_addr = UnixAddr::new(address.as_ref())?;
 

--- a/crates/snapshots/build.rs
+++ b/crates/snapshots/build.rs
@@ -14,9 +14,7 @@
    limitations under the License.
 */
 
-use std::env;
-use std::fs;
-use std::io;
+use std::{env, fs, io};
 
 const PROTO_FILES: &[&str] = &[
     "vendor/github.com/containerd/containerd/api/types/mount.proto",

--- a/crates/snapshots/examples/snapshotter.rs
+++ b/crates/snapshots/examples/snapshotter.rs
@@ -14,17 +14,14 @@
    limitations under the License.
 */
 
-use std::collections::HashMap;
-use std::env;
-
-use futures::TryFutureExt;
-use log::info;
-use tokio::net::UnixListener;
+use std::{collections::HashMap, env};
 
 use containerd_snapshots as snapshots;
 use containerd_snapshots::{api, Info, Usage};
-
+use futures::TryFutureExt;
+use log::info;
 use snapshots::tonic::transport::Server;
+use tokio::net::UnixListener;
 
 #[derive(Default)]
 struct Example;

--- a/crates/snapshots/src/convert.rs
+++ b/crates/snapshots/src/convert.rs
@@ -21,8 +21,7 @@ use std::convert::{TryFrom, TryInto};
 use thiserror::Error;
 use tonic::Status;
 
-use crate::api::snapshots::v1 as grpc;
-use crate::{Info, Kind};
+use crate::{api::snapshots::v1 as grpc, Info, Kind};
 
 impl From<Kind> for i32 {
     fn from(kind: Kind) -> i32 {

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -49,10 +49,7 @@
 //! ```
 //!
 
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::ops::AddAssign;
-use std::time::SystemTime;
+use std::{collections::HashMap, fmt::Debug, ops::AddAssign, time::SystemTime};
 
 pub use tonic;
 

--- a/crates/snapshots/src/wrap.rs
+++ b/crates/snapshots/src/wrap.rs
@@ -16,16 +16,17 @@
 
 //! Trait wrapper to server GRPC requests.
 
-use std::convert::TryInto;
-use std::fmt::Debug;
+use std::{convert::TryInto, fmt::Debug};
 
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::api::snapshots::v1::{
-    snapshots_server::{Snapshots, SnapshotsServer},
-    *,
+use crate::{
+    api::snapshots::v1::{
+        snapshots_server::{Snapshots, SnapshotsServer},
+        *,
+    },
+    Snapshotter,
 };
-use crate::Snapshotter;
 
 pub struct Wrapper<S: Snapshotter> {
     snapshotter: S,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,4 @@
 newline_style = "Unix"
+unstable_features = true # Cargo fmt now needs to be called with `cargo +nightly fmt`
+group_imports = "StdExternalCrate" # Create 3 groups: std, external crates, and self.
+imports_granularity = "Crate" # Merge imports from the same crate into a single use statement


### PR DESCRIPTION
This is a follow up for discussion here: https://github.com/containerd/rust-extensions/pull/95#discussion_r978213442 whether its possible to format imports.
Actually turns out there is a way to enforce it, however the majority of config
items remain unstable, so we have to call cargo fmt with `+nightly` switch.

See new [rustfmt.toml](https://github.com/containerd/rust-extensions/blob/3e521ff3b53f50b6658efa4d91be63bd9f49b65c/rustfmt.toml)

@Burning1020 WDYT?

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>