### PR TITLE
Update GitHub actions packages in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout extensions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
         with:
@@ -111,7 +111,7 @@ jobs:
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Checkout containerd
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: containerd/containerd
           path: src/github.com/containerd/containerd


### PR DESCRIPTION
* Updated actions/checkout from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>