### PR TITLE
runc-shim: fix leaking files for exec process

### DIFF
--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -17,7 +17,7 @@
 
 use std::{
     convert::TryFrom,
-    fs::File,
+    fs::{remove_file, File},
     io::{BufRead, BufReader, Read},
     os::unix::prelude::ExitStatusExt,
     path::{Path, PathBuf},
@@ -267,6 +267,9 @@ impl Container for RuncContainer {
         match exec_id_opt {
             Some(exec_id) => {
                 self.common.processes.remove(exec_id);
+                let exec_pid_path =
+                    Path::new(self.common.bundle.as_str()).join(format!("{}.pid", exec_id));
+                remove_file(exec_pid_path).unwrap_or_default();
             }
             None => {
                 self.common


### PR DESCRIPTION
A pid file under bundle path will be created after the exec process created, so it should also be deleted before process deleted.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>