### PR TITLE
runc-shim: fix leaking thread and fd

### DIFF
--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -34,14 +34,14 @@ use nix::{
     sys::{signal::kill, stat::Mode},
     unistd::{mkdir, Pid},
 };
-use oci_spec::runtime::{LinuxNamespaceType, LinuxResources};
+use oci_spec::runtime::LinuxResources;
 use runc::{Command, Spawner};
 use shim::{
     api::*,
     console::ConsoleSocket,
     error::{Error, Result},
     io::Stdio,
-    monitor::{monitor_subscribe, wait_pid, ExitEvent, Subject, Subscription, Topic},
+    monitor::{monitor_subscribe, wait_pid, Topic},
     mount::mount_rootfs,
     other, other_error,
     protos::{
@@ -345,7 +345,7 @@ impl Container for RuncContainer {
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn update(&mut self, resources: &LinuxResources) -> Result<()> {
+    fn update(&mut self, _resources: &LinuxResources) -> Result<()> {
         Err(Error::Unimplemented("update".to_string()))
     }
 

--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -17,14 +17,14 @@
 
 use std::{
     convert::TryFrom,
-    fs::{remove_file, File},
+    fs::{remove_file, File, OpenOptions},
     io::{BufRead, BufReader, Read},
     os::unix::prelude::ExitStatusExt,
     path::{Path, PathBuf},
     process::ExitStatus,
     sync::{
         mpsc::{Receiver, SyncSender},
-        Arc,
+        Arc, Mutex,
     },
 };
 
@@ -203,7 +203,23 @@ impl Container for RuncContainer {
                     .init
                     .runtime
                     .exec(&id, &process.spec, Some(&exec_opts))
-                    .map_err(|e| runtime_error(&bundle, e, "OCI runtime exec failed"))?;
+                    .map_err(other_error!(e, "failed exec"))?;
+
+                if !process.common.stdio.stdin.is_empty() {
+                    let stdin_clone = process.common.stdio.stdin.clone();
+                    let stdin_w = process.common.stdin.clone();
+                    // Open the write side in advance to make sure read side will not block,
+                    // open it in another thread otherwise it will block too.
+                    std::thread::spawn(move || {
+                        if let Ok(stdin_w_file) =
+                            OpenOptions::new().write(true).open(stdin_clone.as_str())
+                        {
+                            let mut lock_guard = stdin_w.lock().unwrap();
+                            *lock_guard = Some(stdin_w_file);
+                        }
+                    });
+                }
+
                 if process.common.stdio.terminal {
                     let console_socket =
                         socket.ok_or_else(|| other!("failed to get console socket"))?;
@@ -368,6 +384,11 @@ impl Container for RuncContainer {
     fn id(&self) -> String {
         self.common.id.to_string()
     }
+
+    fn close_io(&mut self, exec_id: Option<&str>) -> Result<()> {
+        let p = self.common.get_mut_process(exec_id)?;
+        p.close_io()
+    }
 }
 
 impl RuncContainer {
@@ -424,6 +445,7 @@ impl InitProcess {
                 exited_at: None,
                 wait_chan_tx: vec![],
                 console: None,
+                stdin: Arc::new(Mutex::new(None)),
             },
             bundle: bundle.to_string(),
             runtime,
@@ -548,6 +570,10 @@ impl Process for InitProcess {
     fn resize_pty(&mut self, height: u32, width: u32) -> Result<()> {
         self.common.resize_pty(height, width)
     }
+
+    fn close_io(&self) -> Result<()> {
+        self.common.close_io()
+    }
 }
 
 pub(crate) struct ExecProcess {
@@ -623,6 +649,10 @@ impl Process for ExecProcess {
     fn resize_pty(&mut self, height: u32, width: u32) -> Result<()> {
         self.common.resize_pty(height, width)
     }
+
+    fn close_io(&self) -> Result<()> {
+        self.common.close_io()
+    }
 }
 
 impl TryFrom<ExecProcessRequest> for ExecProcess {
@@ -645,6 +675,7 @@ impl TryFrom<ExecProcessRequest> for ExecProcess {
                 exited_at: None,
                 wait_chan_tx: vec![],
                 console: None,
+                stdin: Arc::new(Mutex::new(None)),
             },
             spec: p,
         };

--- a/crates/runc-shim/src/synchronous/service.rs
+++ b/crates/runc-shim/src/synchronous/service.rs
@@ -18,7 +18,6 @@
 
 use std::{
     env::current_dir,
-    path::Path,
     sync::{
         mpsc::{channel, Receiver, Sender},
         Arc,
@@ -27,18 +26,14 @@ use std::{
 
 use containerd_shim as shim;
 use log::{debug, error};
-use runc::options::{DeleteOpts, GlobalOpts, DEFAULT_COMMAND};
+use runc::options::DeleteOpts;
 use shim::{
     api::*,
-    error::{Error, Result},
+    error::Error,
     event::Event,
     io_error,
     monitor::{monitor_subscribe, Subject, Subscription, Topic},
-    other_error,
-    protos::{
-        events::task::TaskExit,
-        protobuf::{Message, MessageDyn},
-    },
+    protos::{events::task::TaskExit, protobuf::MessageDyn},
     publisher::RemotePublisher,
     spawn,
     util::{

--- a/crates/runc-shim/src/synchronous/task.rs
+++ b/crates/runc-shim/src/synchronous/task.rs
@@ -262,8 +262,13 @@ where
         Ok(Empty::new())
     }
 
-    fn close_io(&self, _ctx: &TtrpcContext, _req: CloseIORequest) -> TtrpcResult<Empty> {
-        // unnecessary close io here since fd was closed automatically after object was destroyed.
+    fn close_io(&self, _ctx: &TtrpcContext, req: CloseIORequest) -> TtrpcResult<Empty> {
+        let mut containers = self.containers.lock().unwrap();
+        let container = containers
+            .get_mut(&req.id)
+            .ok_or_else(|| Error::Other(format!("can not find container by id {}", &req.id)))?;
+        let exec_id_opt = req.exec_id().none_if(|x| x.is_empty());
+        container.close_io(exec_id_opt)?;
         Ok(Empty::new())
     }
 

--- a/crates/shim/src/asynchronous/container.rs
+++ b/crates/shim/src/asynchronous/container.rs
@@ -49,6 +49,7 @@ pub trait Container {
     async fn update(&mut self, resources: &LinuxResources) -> Result<()>;
     async fn stats(&self) -> Result<Metrics>;
     async fn all_processes(&self) -> Result<Vec<ProcessInfo>>;
+    async fn close_io(&mut self, exec_id: Option<&str>) -> Result<()>;
 }
 
 #[async_trait]
@@ -181,6 +182,11 @@ where
 
     async fn all_processes(&self) -> Result<Vec<ProcessInfo>> {
         self.init.ps().await
+    }
+
+    async fn close_io(&mut self, exec_id: Option<&str>) -> Result<()> {
+        let process = self.get_mut_process(exec_id)?;
+        process.close_io().await
     }
 }
 

--- a/crates/shim/src/asynchronous/processes.rs
+++ b/crates/shim/src/asynchronous/processes.rs
@@ -14,7 +14,10 @@
    limitations under the License.
 */
 
-use std::{os::unix::io::AsRawFd, sync::Arc};
+use std::{
+    os::unix::io::AsRawFd,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use containerd_shim_protos::{
@@ -24,7 +27,10 @@ use containerd_shim_protos::{
 };
 use oci_spec::runtime::LinuxResources;
 use time::OffsetDateTime;
-use tokio::sync::oneshot::{channel, Receiver, Sender};
+use tokio::{
+    fs::File,
+    sync::oneshot::{channel, Receiver, Sender},
+};
 
 use crate::{io::Stdio, ioctl_set_winsz, util::asyncify, Console};
 
@@ -43,6 +49,7 @@ pub trait Process {
     async fn update(&mut self, resources: &LinuxResources) -> crate::Result<()>;
     async fn stats(&self) -> crate::Result<Metrics>;
     async fn ps(&self) -> crate::Result<Vec<ProcessInfo>>;
+    async fn close_io(&mut self) -> crate::Result<()>;
 }
 
 #[async_trait]
@@ -65,6 +72,7 @@ pub struct ProcessTemplate<S> {
     pub wait_chan_tx: Vec<Sender<()>>,
     pub console: Option<Console>,
     pub lifecycle: Arc<S>,
+    pub stdin: Arc<Mutex<Option<File>>>,
 }
 
 impl<S> ProcessTemplate<S> {
@@ -79,6 +87,7 @@ impl<S> ProcessTemplate<S> {
             wait_chan_tx: vec![],
             console: None,
             lifecycle: Arc::new(lifecycle),
+            stdin: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -175,5 +184,13 @@ where
 
     async fn ps(&self) -> crate::Result<Vec<ProcessInfo>> {
         self.lifecycle.ps(self).await
+    }
+
+    async fn close_io(&mut self) -> crate::Result<()> {
+        let mut lock_guard = self.stdin.lock().unwrap();
+        if let Some(stdin_w_file) = lock_guard.take() {
+            drop(stdin_w_file);
+        }
+        Ok(())
     }
 }

--- a/crates/shim/src/asynchronous/task.rs
+++ b/crates/shim/src/asynchronous/task.rs
@@ -269,8 +269,9 @@ where
         Ok(Empty::new())
     }
 
-    async fn close_io(&self, _ctx: &TtrpcContext, _req: CloseIORequest) -> TtrpcResult<Empty> {
-        // TODO call close_io of container
+    async fn close_io(&self, _ctx: &TtrpcContext, req: CloseIORequest) -> TtrpcResult<Empty> {
+        let mut container = self.get_container(req.id()).await?;
+        container.close_io(req.exec_id().as_option()).await?;
         Ok(Empty::new())
     }
 


### PR DESCRIPTION
The stdin fifo fd should be closed when containerd calls close io, otherwise, runc-shim would hold this fd and the copy console thread forever.