### PR TITLE
Implement `Serialize` and `Deserialize` for `Kind` and `Info`

### DIFF
--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -18,6 +18,7 @@ prost = "0.11"
 prost-types = "0.11"
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.8"
+serde = { version = "1.0", features = ["derive"] }
 
 # tonic v0.8.1 depends on axum-core v0.2.2, which has security vulnerability:
 #  = ID: RUSTSEC-2022-0055

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -55,6 +55,7 @@
 
 use std::{collections::HashMap, fmt::Debug, ops::AddAssign, time::SystemTime};
 
+use serde::{Deserialize, Serialize};
 pub use tonic;
 
 mod convert;
@@ -78,7 +79,7 @@ pub mod api {
 }
 
 /// Snapshot kinds.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Kind {
     Unknown,
     View,
@@ -93,7 +94,7 @@ impl Default for Kind {
 }
 
 /// Information about a particular snapshot.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Info {
     /// Active or committed snapshot.
     pub kind: Kind,


### PR DESCRIPTION
This allows us to use `serde` to serialize and deserialize the information about a particular snapshot so that we can write it to and read it from storage.

Signed-off-by: Wedson Almeida Filho <walmeida@microsoft.com>