### PR TITLE
Implement `list` function

### DIFF
--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -19,6 +19,9 @@ prost-types = "0.11"
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.8"
 serde = { version = "1.0", features = ["derive"] }
+async-stream = "0.3.3"
+futures = "0.3.17"
+pin-utils = "0.1.0"
 
 # tonic v0.8.1 depends on axum-core v0.2.2, which has security vulnerability:
 #  = ID: RUSTSEC-2022-0055

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.8"
 serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.3"
-futures = "0.3.17"
+futures.workspace = true
 pin-utils = "0.1.0"
 
 # tonic v0.8.1 depends on axum-core v0.2.2, which has security vulnerability:


### PR DESCRIPTION
This is needed by remote snapshotters: once they report "already exists", containerd tries to find the snapshot via `list`. If it's not implemented, the "already exists" trick to prevent layer download doesn't work.

This is still missing a filtering function, but allows remote snapshotters to work.