### PR TITLE
Make shim / runc-shim APIs more consistent

### DIFF
--- a/crates/runc-shim/src/asynchronous/container.rs
+++ b/crates/runc-shim/src/asynchronous/container.rs
@@ -17,16 +17,19 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use containerd_shim_protos::{
-    api::{CreateTaskRequest, ExecProcessRequest, ProcessInfo, StateResponse},
-    cgroups::metrics::Metrics,
+use containerd_shim::{
+    asynchronous::processes::Process,
+    error::Result,
+    protos::{
+        api::{CreateTaskRequest, ExecProcessRequest, ProcessInfo, StateResponse},
+        cgroups::metrics::Metrics,
+    },
+    Error,
 };
 use log::debug;
 use oci_spec::runtime::LinuxResources;
 use time::OffsetDateTime;
 use tokio::sync::oneshot::Receiver;
-
-use crate::{asynchronous::processes::Process, error::Result, Error};
 
 #[async_trait]
 pub trait Container {

--- a/crates/runc-shim/src/asynchronous/mod.rs
+++ b/crates/runc-shim/src/asynchronous/mod.rs
@@ -20,13 +20,10 @@ use ::runc::options::DeleteOpts;
 use async_trait::async_trait;
 use containerd_shim::{
     asynchronous::{
-        container::Container,
         monitor::{monitor_subscribe, monitor_unsubscribe, Subscription},
         processes::Process,
         publisher::RemotePublisher,
-        spawn,
-        task::TaskService,
-        ExitSignal, Shim,
+        spawn, ExitSignal, Shim,
     },
     event::Event,
     io_error,
@@ -45,7 +42,12 @@ use crate::{
     common::{create_runc, has_shared_pid_namespace, ShimExecutor, GROUP_LABELS},
 };
 
+mod container;
 mod runc;
+mod task;
+
+use container::Container;
+use task::TaskService;
 
 pub(crate) struct Service {
     exit: Arc<ExitSignal>,

--- a/crates/runc-shim/src/asynchronous/runc.rs
+++ b/crates/runc-shim/src/asynchronous/runc.rs
@@ -30,7 +30,6 @@ use containerd_shim::{
     api::{CreateTaskRequest, ExecProcessRequest, Options, Status},
     asynchronous::{
         console::ConsoleSocket,
-        container::{ContainerFactory, ContainerTemplate, ProcessFactory},
         monitor::{monitor_subscribe, monitor_unsubscribe, Subscription},
         processes::{ProcessLifecycle, ProcessTemplate},
     },
@@ -55,6 +54,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, BufReader},
 };
 
+use super::container::{ContainerFactory, ContainerTemplate, ProcessFactory};
 use crate::common::{
     check_kill_error, create_io, create_runc, get_spec_from_request, receive_socket, CreateConfig,
     Log, ProcessIO, ShimExecutor, INIT_PID_FILE, LOG_JSON_FILE,

--- a/crates/runc-shim/src/asynchronous/task.rs
+++ b/crates/runc-shim/src/asynchronous/task.rs
@@ -17,35 +17,33 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use containerd_shim_protos::{
-    api::{
-        CloseIORequest, ConnectRequest, ConnectResponse, DeleteResponse, PidsRequest, PidsResponse,
-        StatsRequest, StatsResponse, UpdateTaskRequest,
-    },
-    events::task::{TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskIO, TaskStart},
-    protobuf::MessageDyn,
-    shim_async::Task,
-    ttrpc,
-    ttrpc::r#async::TtrpcContext,
-};
-use log::{debug, info, warn};
-use oci_spec::runtime::LinuxResources;
-use tokio::sync::{mpsc::Sender, MappedMutexGuard, Mutex, MutexGuard};
-
-use crate::{
+use containerd_shim::{
     api::{
         CreateTaskRequest, CreateTaskResponse, DeleteRequest, Empty, ExecProcessRequest,
         KillRequest, ResizePtyRequest, ShutdownRequest, StartRequest, StartResponse, StateRequest,
         StateResponse, Status, WaitRequest, WaitResponse,
     },
-    asynchronous::{
-        container::{Container, ContainerFactory},
-        ExitSignal,
-    },
+    asynchronous::ExitSignal,
     event::Event,
+    protos::{
+        api::{
+            CloseIORequest, ConnectRequest, ConnectResponse, DeleteResponse, PidsRequest,
+            PidsResponse, StatsRequest, StatsResponse, UpdateTaskRequest,
+        },
+        events::task::{TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskIO, TaskStart},
+        protobuf::MessageDyn,
+        shim_async::Task,
+        ttrpc,
+        ttrpc::r#async::TtrpcContext,
+    },
     util::{convert_to_any, convert_to_timestamp, AsOption},
     TtrpcResult,
 };
+use log::{debug, info, warn};
+use oci_spec::runtime::LinuxResources;
+use tokio::sync::{mpsc::Sender, MappedMutexGuard, Mutex, MutexGuard};
+
+use super::container::{Container, ContainerFactory};
 
 type EventSender = Sender<(String, Box<dyn MessageDyn>)>;
 

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -59,11 +59,9 @@ use crate::{
 };
 
 pub mod console;
-pub mod container;
 pub mod monitor;
 pub mod processes;
 pub mod publisher;
-pub mod task;
 pub mod util;
 
 /// Asynchronous Main shim interface that must be implemented by all async shims.

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -110,9 +110,7 @@ cfg_not_async! {
 cfg_async! {
     pub use crate::asynchronous::*;
     pub use crate::asynchronous::console;
-    pub use crate::asynchronous::container;
     pub use crate::asynchronous::processes;
-    pub use crate::asynchronous::task;
     pub use crate::asynchronous::publisher;
     pub use protos::shim_async::Task;
     pub use protos::ttrpc::r#async::TtrpcContext;


### PR DESCRIPTION
Current `shim` and `runc-shim` sync/async APIs are not consistent.

In current implementation, async `shim` crate keeps `container` and `task` modules, while sync versions of these modules are kept in `runc-shim` crate.

This PR moves these to `runc-shim` crate for consistency.

In longer run, I'd like to slimify `shim` crate more and remove all implementation details, so it handles shim lifecycle/events only.


<img width="287" alt="image" src="https://user-images.githubusercontent.com/865334/225445818-a1277025-6bce-442b-ae40-65d2dfd3fe81.png">
