### PR TITLE
Derive `PartialEq` for `Kind`

### DIFF
--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -79,7 +79,7 @@ pub mod api {
 }
 
 /// Snapshot kinds.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub enum Kind {
     Unknown,
     View,


### PR DESCRIPTION
This allows us to use the `==` and `!=` operators to compare instances of `Kind`, which is useful when we require that a snapshot be of some specific kind (e.g., committed) before performing an operation on it.