### PR TITLE
release containerd-shim-protos: v0.3.0

### DIFF
--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-protos"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
 description = "TTRPC bindings for containerd shim interfaces"
 keywords = ["containerd", "shim", "containers", "ttrpc", "client"]

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -35,7 +35,7 @@ prctl = "1.0.0"
 page_size = "0.5.0"
 regex = "1"
 
-containerd-shim-protos = { path = "../shim-protos", version = "0.2.0" }
+containerd-shim-protos = { path = "../shim-protos", version = "0.3.0" }
 
 async-trait = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }


### PR DESCRIPTION
Bump containerd-shim-protos from 0.2.0 to 0.3.0 to include changes made in #95.

Because the update in #95 is not compatible we need a major version update.