### PR TITLE
Implement the input parameters for snapshotter::list

### DIFF
--- a/crates/snapshots/examples/snapshotter.rs
+++ b/crates/snapshots/examples/snapshotter.rs
@@ -100,7 +100,12 @@ impl snapshots::Snapshotter for Example {
     }
 
     type InfoStream = EmptyStream;
-    async fn list(&self) -> Result<Self::InfoStream, Self::Error> {
+    async fn list(
+        &self,
+        snapshotter: String,
+        filters: Vec<String>,
+    ) -> Result<Self::InfoStream, Self::Error> {
+        info!("List: snapshotter={}, filters={:?}", snapshotter, filters);
         // Returns no snapshots.
         Ok(EmptyStream)
     }

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -283,5 +283,9 @@ pub trait Snapshotter: Send + Sync + 'static {
     ///         })
     ///     }
     /// ```
-    async fn list(&self) -> Result<Self::InfoStream, Self::Error>;
+    async fn list(
+        &self,
+        snapshotter: String,
+        filters: Vec<String>,
+    ) -> Result<Self::InfoStream, Self::Error>;
 }

--- a/crates/snapshots/src/wrap.rs
+++ b/crates/snapshots/src/wrap.rs
@@ -158,11 +158,12 @@ impl<S: Snapshotter> Snapshots for Wrapper<S> {
 
     async fn list(
         &self,
-        _request: tonic::Request<ListSnapshotsRequest>,
+        request: tonic::Request<ListSnapshotsRequest>,
     ) -> Result<tonic::Response<Self::ListStream>, tonic::Status> {
+        let request = request.into_inner();
         let sn = self.snapshotter.clone();
         let output = async_stream::try_stream! {
-            let walk_stream = sn.list().await?;
+            let walk_stream = sn.list(request.snapshotter, request.filters).await?;
             pin_utils::pin_mut!(walk_stream);
             let mut infos = Vec::<Info>::new();
             while let Some(info) = walk_stream.next().await {


### PR DESCRIPTION
This PR follows up on @wedsonaf's https://github.com/containerd/rust-extensions/pull/126 and pass the filters through the `list` input. Note that this is not backward compatible but this is a step closer to the protocol conformance. 