### PR TITLE
Update tonic dependencies, switch to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,18 @@ panic = 'abort'
 license = "Apache-2.0"
 repository = "https://github.com/containerd/rust-extensions"
 homepage = "https://containerd.io"
-edition = "2018"
+edition = "2021"
 
-# Common crate dependencies
+# Common dependencies for all crates
 [workspace.dependencies]
 tokio = "1.26"
 tower = "0.4"
+
+tonic = "0.9.2"
+tonic-build = "0.9.2"
+
+prost = "0.11"
+prost-types = "0.11"
+
 async-trait = "0.1.52"
 futures = "0.3.19"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-tonic = "0.8"
-prost = "0.11"
-prost-types = "0.11"
+tonic.workspace = true
+prost.workspace = true
+prost-types.workspace = true
 tokio = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 
@@ -30,7 +30,7 @@ tower = { workspace = true, optional = true }
 axum-core = ">=0.2.8"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build.workspace = true
 
 [features]
 connect = ["tokio", "tower"]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -78,8 +78,6 @@ pub mod events {
 pub async fn connect(
     path: impl AsRef<std::path::Path>,
 ) -> Result<tonic::transport::Channel, tonic::transport::Error> {
-    use std::convert::TryFrom;
-
     use tokio::net::UnixStream;
     use tonic::transport::Endpoint;
 

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace = true
 
 [dependencies]
 thiserror = "1.0"
-tonic = "0.8"
-prost = "0.11"
-prost-types = "0.11"
+tonic.workspace = true
+prost.workspace = true
+prost-types.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.8"
 serde = { version = "1.0", features = ["derive"] }
@@ -41,4 +41,4 @@ futures.workspace = true
 simple_logger = { version  = "4.0", default-features = false }
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build.workspace = true


### PR DESCRIPTION
Closes https://github.com/containerd/rust-extensions/pull/133 https://github.com/containerd/rust-extensions/pull/132

This PR updates Tonic dependencies.
Tonic has switched to Rust 2021 edition.
To keep our dependencies up to date, we're switching to 2021 too.