### PR TITLE
Pass all commandline arguments through

### DIFF
--- a/crates/runc-shim/src/asynchronous/mod.rs
+++ b/crates/runc-shim/src/asynchronous/mod.rs
@@ -31,7 +31,7 @@ use containerd_shim::{
     util::{
         convert_to_timestamp, read_options, read_runtime, read_spec, timestamp, write_str_to_file,
     },
-    Config, Context, DeleteResponse, Error, StartOpts,
+    Config, Context, DeleteResponse, Error, Flags, StartOpts,
 };
 use log::{debug, error, warn};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -61,13 +61,13 @@ pub(crate) struct Service {
 impl Shim for Service {
     type T = TaskService<RuncFactory, RuncContainer>;
 
-    async fn new(_runtime_id: &str, id: &str, namespace: &str, _config: &mut Config) -> Self {
+    async fn new(_runtime_id: &str, args: &Flags, _config: &mut Config) -> Self {
         let exit = Arc::new(ExitSignal::default());
         // TODO: add publisher
         Service {
             exit,
-            id: id.to_string(),
-            namespace: namespace.to_string(),
+            id: args.id.to_string(),
+            namespace: args.namespace.to_string(),
         }
     }
 

--- a/crates/runc-shim/src/synchronous/service.rs
+++ b/crates/runc-shim/src/synchronous/service.rs
@@ -40,7 +40,7 @@ use shim::{
         convert_to_timestamp, read_options, read_runtime, read_spec_from_file, timestamp,
         write_address,
     },
-    warn, Config, Context, ExitSignal, Shim, StartOpts,
+    warn, Config, Context, ExitSignal, Flags, Shim, StartOpts,
 };
 
 use crate::{
@@ -56,11 +56,11 @@ use crate::{
 impl Shim for Service {
     type T = ShimTask<RuncFactory, RuncContainer>;
 
-    fn new(_runtime_id: &str, id: &str, namespace: &str, _config: &mut Config) -> Self {
+    fn new(_runtime_id: &str, args: &Flags, _config: &mut Config) -> Self {
         Service {
             exit: Arc::new(ExitSignal::default()),
-            id: id.to_string(),
-            namespace: namespace.to_string(),
+            id: args.id.to_string(),
+            namespace: args.namespace.to_string(),
         }
     }
 

--- a/crates/shim/examples/skeleton.rs
+++ b/crates/shim/examples/skeleton.rs
@@ -23,7 +23,7 @@ mod skeleton {
     use containerd_shim as shim;
     use log::info;
     use shim::{
-        api, synchronous::publisher::RemotePublisher, Config, DeleteResponse, ExitSignal,
+        api, synchronous::publisher::RemotePublisher, Config, DeleteResponse, ExitSignal, Flags,
         TtrpcContext, TtrpcResult,
     };
 
@@ -35,7 +35,7 @@ mod skeleton {
     impl shim::Shim for Service {
         type T = Service;
 
-        fn new(_runtime_id: &str, _id: &str, _namespace: &str, _config: &mut Config) -> Self {
+        fn new(_runtime_id: &str, _args: &Flags, _config: &mut Config) -> Self {
             Service {
                 exit: Arc::new(ExitSignal::default()),
             }

--- a/crates/shim/examples/skeleton_async.rs
+++ b/crates/shim/examples/skeleton_async.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use containerd_shim::{
     asynchronous::{run, spawn, ExitSignal, Shim},
     publisher::RemotePublisher,
-    Config, Error, StartOpts, TtrpcResult,
+    Config, Error, Flags, StartOpts, TtrpcResult,
 };
 use containerd_shim_protos::{
     api, api::DeleteResponse, shim_async::Task, ttrpc::r#async::TtrpcContext,
@@ -36,7 +36,7 @@ struct Service {
 impl Shim for Service {
     type T = Service;
 
-    async fn new(_runtime_id: &str, _id: &str, _namespace: &str, _config: &mut Config) -> Self {
+    async fn new(_runtime_id: &str, _args: &Flags, _config: &mut Config) -> Self {
         Service {
             exit: Arc::new(ExitSignal::default()),
         }

--- a/crates/shim/src/args.rs
+++ b/crates/shim/src/args.rs
@@ -19,7 +19,7 @@ use std::ffi::OsStr;
 use crate::error::{Error, Result};
 
 /// Flags to be passed from containerd daemon to a shim binary.
-/// Reflects https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L100
+/// Reflects <https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L100>
 #[derive(Debug, Default)]
 pub struct Flags {
     /// Enable debug output in logs.
@@ -37,7 +37,7 @@ pub struct Flags {
     /// Path to publish binary (used for publishing events).
     pub publish_binary: String,
     /// Shim action (start / delete).
-    /// See https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L191
+    /// See <https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L191>
     pub action: String,
 }
 

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     error::{Error, Result},
     logger, parse_sockaddr, reap, socket_address,
     util::{asyncify, read_file_to_str, write_str_to_file},
-    Config, StartOpts, SOCKET_FD, TTRPC_ADDRESS,
+    Config, Flags, StartOpts, SOCKET_FD, TTRPC_ADDRESS,
 };
 
 pub mod monitor;
@@ -77,7 +77,7 @@ pub trait Shim {
     /// - `id`: identifier of the shim/container, passed in from Containerd.
     /// - `namespace`: namespace of the shim/container, passed in from Containerd.
     /// - `config`: for the shim to pass back configuration information
-    async fn new(runtime_id: &str, id: &str, namespace: &str, config: &mut Config) -> Self;
+    async fn new(runtime_id: &str, args: &Flags, config: &mut Config) -> Self;
 
     /// Start shim will be called by containerd when launching new shim instance.
     ///
@@ -128,7 +128,7 @@ where
         reap::set_subreaper()?;
     }
 
-    let mut shim = T::new(runtime_id, &flags.id, &flags.namespace, &mut config).await;
+    let mut shim = T::new(runtime_id, &flags, &mut config).await;
 
     match flags.action.as_str() {
         "start" => {

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -65,6 +65,7 @@ pub use crate::synchronous::*;
 pub mod error;
 
 mod args;
+pub use args::Flags;
 #[cfg(feature = "async")]
 pub mod asynchronous;
 pub mod cgroup;

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -62,7 +62,8 @@ use util::{read_address, write_address};
 
 use crate::{
     api::DeleteResponse,
-    args, logger,
+    args::{self, Flags},
+    logger,
     protos::{
         protobuf::Message,
         shim::shim_ttrpc::{create_task, Task},
@@ -159,10 +160,9 @@ pub trait Shim {
     ///
     /// # Arguments
     /// - `runtime_id`: identifier of the container runtime.
-    /// - `id`: identifier of the shim/container, passed in from Containerd.
-    /// - `namespace`: namespace of the shim/container, passed in from Containerd.
+    /// - `args`: command line arguments passed to the shim which includes namespace and id
     /// - `config`: for the shim to pass back configuration information
-    fn new(runtime_id: &str, id: &str, namespace: &str, config: &mut Config) -> Self;
+    fn new(runtime_id: &str, args: &Flags, config: &mut Config) -> Self;
 
     /// Start shim will be called by containerd when launching new shim instance.
     ///
@@ -213,7 +213,7 @@ where
         reap::set_subreaper()?;
     }
 
-    let mut shim = T::new(runtime_id, &flags.id, &flags.namespace, &mut config);
+    let mut shim = T::new(runtime_id, &flags, &mut config);
 
     match flags.action.as_str() {
         "start" => {


### PR DESCRIPTION
Because the second invocation of the shim doesn't have the containerd pipe passed to it, a shim that wants to communicate over the pipe needs to parse the arguments its own.  This makes it so the library pass all the arguments, which has already parsed the arguments allowing shims to use the containerd address.

This came up in runwasi: https://github.com/containerd/runwasi/pull/147#pullrequestreview-1495745320