### PR TITLE
Add missing condition to stop reaping child procs

### DIFF
--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -332,6 +332,9 @@ async fn handle_signals(signals: Signals) {
                             .await
                             .unwrap_or_else(|e| error!("failed to send signal event {}", e))
                     }
+                    Ok(WaitStatus::StillAlive) => {
+                        break;
+                    }
                     Err(Error::Nix(Errno::ECHILD)) => {
                         break;
                     }

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -354,6 +354,9 @@ fn handle_signals(mut _signals: Option<AppSignals>) {
                                 monitor::monitor_notify_by_pid(pid.as_raw(), exit_code)
                                     .unwrap_or_else(|e| error!("failed to send signal event {}", e))
                             }
+                            Ok(WaitStatus::StillAlive) => {
+                                break;
+                            }
                             Err(Errno::ECHILD) => {
                                 break;
                             }


### PR DESCRIPTION
Since PR #75 the loop that reaps child processes is not properly stopping.
Since `WaitPidFlag::WNOHANG` is being used, the `WaitStatus::StillAlive` status [should also be considered](https://docs.rs/nix/latest/nix/sys/wait/enum.WaitStatus.html#variant.StillAlive).

> #### StillAlive
> There are currently no state changes to report in any awaited child process. This is only returned if WaitPidFlag::WNOHANG was used (otherwise wait() or waitpid() would block until there was something to report).

This is equivalent to the `res_pid == 0` condition before PR #75.