### PR TITLE
Fix dependencies

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -18,17 +18,6 @@ prost-types.workspace = true
 tokio = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 
-# tonic v0.8.1 depends on axum-core v0.2.2, which has security vulnerability:
-#  = ID: RUSTSEC-2022-0055
-#  = Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0055
-#  = `<bytes::Bytes as axum_core::extract::FromRequest>::from_request` would not, by
-#    default, set a limit for the size of the request body. That meant if a malicious
-#    peer would send a very large (or infinite) body your server might run out of
-#    memory and crash.
-#
-# This needs to be removed once newer version of tonic is released.
-axum-core = ">=0.2.8"
-
 [build-dependencies]
 tonic-build.workspace = true
 

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -23,7 +23,7 @@ path-absolutize = "3.0.11"
 rand = "0.8.4"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
-tempfile = "3.3.0"
+tempfile = "3.6.0"
 thiserror = "1.0.30"
 time = { version = "0.3.7", features = ["serde", "std"] }
 uuid = { version = "1.0.0", features = ["v4"] }

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -23,17 +23,6 @@ async-stream = "0.3.3"
 futures.workspace = true
 pin-utils = "0.1.0"
 
-# tonic v0.8.1 depends on axum-core v0.2.2, which has security vulnerability:
-#  = ID: RUSTSEC-2022-0055
-#  = Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0055
-#  = `<bytes::Bytes as axum_core::extract::FromRequest>::from_request` would not, by
-#    default, set a limit for the size of the request body. That meant if a malicious
-#    peer would send a very large (or infinite) body your server might run out of
-#    memory and crash.
-#
-# This needs to be removed once newer version of tonic is released.
-axum-core = ">=0.2.8"
-
 [dev-dependencies]
 log = "0.4"
 async-stream = "0.3.2"


### PR DESCRIPTION
Update `tempfile` version as it was failing for me locally:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /Users/mxpv/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.8/src/lib.rs:99:26
   |
99 | #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
   |                          ^^^^^^^^^^^^^^^^^^^^
```

and cleanup the old workaround for `axum-core`