### PR TITLE
runc-shim: open read side of stdout/stderr fifo to avoid EPIPE

### DIFF
--- a/crates/runc-shim/src/io.rs
+++ b/crates/runc-shim/src/io.rs
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Stdio {
     pub stdin: String,
     pub stdout: String,

--- a/crates/runc-shim/src/synchronous/container.rs
+++ b/crates/runc-shim/src/synchronous/container.rs
@@ -65,7 +65,7 @@ pub trait Process {
     fn exit_code(&self) -> i32;
     fn exited_at(&self) -> Option<OffsetDateTime>;
     fn copy_console(&self, console_socket: &ConsoleSocket) -> Result<Console>;
-    fn copy_io(&self) -> Result<()>;
+    fn copy_io(&mut self) -> Result<()>;
     fn set_pid_from_file(&mut self, pid_path: &Path) -> Result<()>;
     fn resize_pty(&mut self, height: u32, width: u32) -> Result<()>;
     fn close_io(&self) -> Result<()>;
@@ -302,8 +302,8 @@ impl Process for CommonProcess {
         Ok(console)
     }
 
-    fn copy_io(&self) -> Result<()> {
-        if let Some(pio) = self.io.as_ref() {
+    fn copy_io(&mut self) -> Result<()> {
+        if let Some(pio) = self.io.as_mut() {
             pio.copy(&self.stdio)?;
         };
         Ok(())

--- a/crates/runc-shim/src/synchronous/runc.rs
+++ b/crates/runc-shim/src/synchronous/runc.rs
@@ -559,7 +559,7 @@ impl Process for InitProcess {
         self.common.copy_console(console_socket)
     }
 
-    fn copy_io(&self) -> Result<()> {
+    fn copy_io(&mut self) -> Result<()> {
         self.common.copy_io()
     }
 
@@ -638,7 +638,7 @@ impl Process for ExecProcess {
         self.common.copy_console(console_socket)
     }
 
-    fn copy_io(&self) -> Result<()> {
+    fn copy_io(&mut self) -> Result<()> {
         self.common.copy_io()
     }
 


### PR DESCRIPTION
The "read" side of container stdout/stderr fifo has been opened by containerd and on the other hand "write" side is opened by container process, which is a little different with golang shim. If containerd shutdown and closed the read fd, container process will receive EPIPE when writing to stdout/stderr and then be killed by SIGPIPE signal. In this commit, the "read" side is opened again by shim so that at least there is one opened "read" side all the time.

Fix #100 