### PR TITLE
chore: bump rust version to 1.71

### DIFF
--- a/crates/logging/examples/journal.rs
+++ b/crates/logging/examples/journal.rs
@@ -22,7 +22,7 @@ use logging::{Config, Driver};
 fn pump(reader: fs::File) {
     io::BufReader::new(reader)
         .lines()
-        .filter_map(|line| line.ok())
+        .map_while(Result::ok)
         .for_each(|_str| {
             // Write log string to destination here.
             // For instance with journald:

--- a/crates/snapshots/examples/snapshotter.rs
+++ b/crates/snapshots/examples/snapshotter.rs
@@ -133,7 +133,7 @@ async fn main() {
         .ok_or("First argument must be socket path")
         .unwrap();
 
-    let example = Example::default();
+    let example = Example;
 
     let incoming = {
         let uds = UnixListener::bind(socket_path).expect("Failed to bind listener");

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -80,18 +80,13 @@ pub mod api {
 }
 
 /// Snapshot kinds.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
 pub enum Kind {
+    #[default]
     Unknown,
     View,
     Active,
     Committed,
-}
-
-impl Default for Kind {
-    fn default() -> Self {
-        Kind::Unknown
-    }
 }
 
 /// Information about a particular snapshot.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66"
+channel = "1.71"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
this PR bumps the rust version to the newest 1.71 and closes #160 