### PR TITLE
feat: add cgroup v2 support for metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         containerd: [v1.6.21, v1.7.1]
 
     steps:


### PR DESCRIPTION
This commits adds cgroup v2 support for collecting metrics in the shim.

Additionally, it uses CPU controller instead of the CPUAcct controller
for reporting CPU metrics back to `containerd`.

Closes #162 