### PR TITLE
[Windows] Ensure the correct cargo project is selected for run

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -94,8 +94,8 @@ jobs:
           $env:TTRPC_ADDRESS="\\.\pipe\containerd-containerd.ttrpc"  
 
           # run the example 
-          cargo run --example skeleton -- -namespace default -id 1234 -address "\\.\pipe\containerd-containerd"  -publish-binary ./bin/containerd start 
+          cargo run -p containerd-shim --example skeleton -- -namespace default -id 1234 -address "\\.\pipe\containerd-containerd"  -publish-binary ./bin/containerd start 
           ps skeleton 
-          cargo run --example shim-proto-connect \\.\pipe\containerd-shim-17630016127144989388-pipe
+          cargo run -p containerd-shim-protos --example shim-proto-connect \\.\pipe\containerd-shim-17630016127144989388-pipe
           $skeleton = get-process skeleton -ErrorAction SilentlyContinue
           if ($skeleton) { exit 1 }


### PR DESCRIPTION
in #155 after sync methods were removed from runc shim, cargo was defaulting to the wrong package settings when running the examples.  This forces the `cargo run` to run in the context of the projects that support windows (and there for don't have async turned on).