### PR TITLE
feat(runc-shim): add a version flag

### DIFF
--- a/crates/runc-shim/build.rs
+++ b/crates/runc-shim/build.rs
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use std::{process::Command, str::from_utf8};
+
+fn main() {
+    let output = match Command::new("git").arg("rev-parse").arg("HEAD").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+    let mut hash = from_utf8(&output.stdout).unwrap().trim().to_string();
+
+    let output_dirty = match Command::new("git").arg("diff").arg("--exit-code").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+
+    if !output_dirty.status.success() {
+        hash.push_str(".m");
+    }
+    println!("cargo:rustc-env=CARGO_GIT_HASH={}", hash);
+}

--- a/crates/runc-shim/src/main.rs
+++ b/crates/runc-shim/src/main.rs
@@ -14,7 +14,9 @@
    limitations under the License.
 */
 
-use containerd_shim::asynchronous::run;
+use std::env;
+
+use containerd_shim::{asynchronous::run, parse};
 
 mod common;
 mod console;
@@ -27,7 +29,21 @@ mod task;
 
 use service::Service;
 
+fn parse_version() {
+    let os_args: Vec<_> = env::args_os().collect();
+    let flags = parse(&os_args[1..]).unwrap();
+    if flags.version {
+        println!("{}:", os_args[0].to_string_lossy());
+        println!("  Version: {}", env!("CARGO_PKG_VERSION"));
+        println!("  Revision: {}", env!("CARGO_GIT_HASH"));
+        println!();
+
+        std::process::exit(0);
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    parse_version();
     run::<Service>("io.containerd.runc.v2-rs", None).await;
 }

--- a/crates/shim/src/args.rs
+++ b/crates/shim/src/args.rs
@@ -39,15 +39,17 @@ pub struct Flags {
     /// Shim action (start / delete).
     /// See <https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L191>
     pub action: String,
+    /// Version of the shim.
+    pub version: bool,
 }
 
 /// Parses command line arguments passed to the shim.
-/// This func replicates https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L110
 pub fn parse<S: AsRef<OsStr>>(args: &[S]) -> Result<Flags> {
     let mut flags = Flags::default();
 
     let args: Vec<String> = go_flag::parse_args(args, |f| {
         f.add_flag("debug", &mut flags.debug);
+        f.add_flag("v", &mut flags.version);
         f.add_flag("namespace", &mut flags.namespace);
         f.add_flag("id", &mut flags.id);
         f.add_flag("socket", &mut flags.socket);
@@ -59,12 +61,6 @@ pub fn parse<S: AsRef<OsStr>>(args: &[S]) -> Result<Flags> {
 
     if let Some(action) = args.get(0) {
         flags.action = action.into();
-    }
-
-    if flags.namespace.is_empty() {
-        return Err(Error::InvalidArgument(String::from(
-            "Shim namespace cannot be empty",
-        )));
     }
 
     Ok(flags)
@@ -124,12 +120,5 @@ mod tests {
         let flags = parse(&args).unwrap();
         assert_eq!(flags.action, "start");
         assert_eq!(flags.id, "");
-    }
-
-    #[test]
-    fn no_namespace() {
-        let empty: [String; 0] = [];
-        let result = parse(&empty).err();
-        assert!(result.is_some())
     }
 }

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::synchronous::*;
 pub mod error;
 
 mod args;
-pub use args::Flags;
+pub use args::{parse, Flags};
 #[cfg(feature = "async")]
 pub mod asynchronous;
 pub mod cgroup;


### PR DESCRIPTION
This PR adds two things
1. expose the `parse` function from `containerd-shim` crate and move the namespace check to the boostrap function
2. implement git hash for helping the version information on the runc-shim. 

Closes #120