### PR TITLE
Automatically assign labels to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - T-dependencies
 
   # Ensure that references to actions in a repository's workflow.yml file are kept up to date.
   # See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
@@ -11,3 +13,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      # Mark PRs as CI related change.
+      - T-CI

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+# Automatically assign labels to PRs.
+# `C-` project crate(s) affected.
+# `T-` change type (CI, docs, etc).
+
+C-client: crates/client/**
+C-logging: crates/logging/**
+C-runc: crates/runc/**
+C-runc-shim: crates/runc-shim/**
+C-shim: crates/shim/**
+C-shim-protos: crates/shim-protos/**
+C-snapshots: crates/snapshots/**
+
+T-CI:
+- .github/**
+- *.toml
+
+T-docs:
+- **/*.md

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: PR Labeler
+on:
+  # Runs workflow when activity on a PR in the workflow's repository occurs.
+  pull_request_target:
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+
+    name: Assign labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        # Auto-include paths starting with dot (e.g. .github)
+        dot: true
+        # Remove labels when matching files are reverted or no longer changed by the PR
+        sync-labels: true


### PR DESCRIPTION
I've been playing with various options to generate changelog between releases and it'd be useful to categories PRs (e.g. distinguish PRs to different crates).


This PR adds a CI job to automatically assign proper labels depending on change type.

cc: @Mossaka @jsturtevant 