### PR TITLE
Improve containerd client ergonomics

### DIFF
--- a/crates/client/examples/version.rs
+++ b/crates/client/examples/version.rs
@@ -14,18 +14,20 @@
    limitations under the License.
 */
 
-use client::services::v1::version_client::VersionClient;
-use containerd_client as client;
+use containerd_client::Client;
 
 /// Make sure you run containerd before running this example.
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let channel = client::connect("/run/containerd/containerd.sock")
+    let client = Client::from_path("/var/run/containerd/containerd.sock")
         .await
-        .expect("Connect Failed");
+        .expect("Connect failed");
 
-    let mut client = VersionClient::new(channel);
-    let resp = client.version(()).await.expect("Failed to query version");
+    let resp = client
+        .version()
+        .version(())
+        .await
+        .expect("Failed to query version");
 
     println!("Response: {:?}", resp.get_ref());
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -107,3 +107,123 @@ macro_rules! with_namespace {
         req
     }};
 }
+
+use services::v1::{
+    containers_client::ContainersClient,
+    content_client::ContentClient,
+    diff_client::DiffClient,
+    events_client::EventsClient,
+    images_client::ImagesClient,
+    introspection_client::IntrospectionClient,
+    leases_client::LeasesClient,
+    namespaces_client::NamespacesClient,
+    sandbox::{controller_client::ControllerClient, store_client::StoreClient},
+    snapshots::snapshots_client::SnapshotsClient,
+    tasks_client::TasksClient,
+    version_client::VersionClient,
+};
+use tonic::transport::{Channel, Error};
+
+/// Client to containerd's APIs.
+pub struct Client {
+    channel: Channel,
+}
+
+impl From<Channel> for Client {
+    fn from(value: Channel) -> Self {
+        Self { channel: value }
+    }
+}
+
+impl Client {
+    /// Create a new client from UDS socket.
+    #[cfg(feature = "connect")]
+    pub async fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
+        let channel = connect(path).await?;
+        Ok(Self { channel })
+    }
+
+    /// Access to the underlying Tonic channel.
+    #[inline]
+    pub fn channel(&self) -> Channel {
+        self.channel.clone()
+    }
+
+    /// Version service.
+    #[inline]
+    pub fn version(&self) -> VersionClient<Channel> {
+        VersionClient::new(self.channel())
+    }
+
+    /// Task service client.
+    #[inline]
+    pub fn tasks(&self) -> TasksClient<Channel> {
+        TasksClient::new(self.channel())
+    }
+
+    /// Sandbox store client.
+    #[inline]
+    pub fn sandbox_store(&self) -> StoreClient<Channel> {
+        StoreClient::new(self.channel())
+    }
+
+    /// Sandbox controller client.
+    #[inline]
+    pub fn sandbox_controller(&self) -> ControllerClient<Channel> {
+        ControllerClient::new(self.channel())
+    }
+
+    /// Snapshots service.
+    #[inline]
+    pub fn snapshots(&self) -> SnapshotsClient<Channel> {
+        SnapshotsClient::new(self.channel())
+    }
+
+    /// Namespaces service.
+    #[inline]
+    pub fn namespaces(&self) -> NamespacesClient<Channel> {
+        NamespacesClient::new(self.channel())
+    }
+
+    /// Leases service.
+    #[inline]
+    pub fn leases(&self) -> LeasesClient<Channel> {
+        LeasesClient::new(self.channel())
+    }
+
+    /// Intropection service.
+    #[inline]
+    pub fn introspection(&self) -> IntrospectionClient<Channel> {
+        IntrospectionClient::new(self.channel())
+    }
+
+    /// Image service.
+    #[inline]
+    pub fn images(&self) -> ImagesClient<Channel> {
+        ImagesClient::new(self.channel())
+    }
+
+    /// Event service.
+    #[inline]
+    pub fn events(&self) -> EventsClient<Channel> {
+        EventsClient::new(self.channel())
+    }
+
+    /// Diff service.
+    #[inline]
+    pub fn diff(&self) -> DiffClient<Channel> {
+        DiffClient::new(self.channel())
+    }
+
+    /// Content service.
+    #[inline]
+    pub fn content(&self) -> ContentClient<Channel> {
+        ContentClient::new(self.channel())
+    }
+
+    /// Container service.
+    #[inline]
+    pub fn containers(&self) -> ContainersClient<Channel> {
+        ContainersClient::new(self.channel())
+    }
+}


### PR DESCRIPTION
Make containerd client a bit more user friendly.

Instead of

```rust
   let channel = client::connect("/run/containerd/containerd.sock")
        .await
        .expect("Connect Failed");

    let mut client = VersionClient::new(channel);
    let resp = client.version(()).await.expect("Failed to query version");
```

we can do

```rust
    let client = Client::from_path("/var/run/containerd/containerd.sock")
        .await
        .expect("Connect failed");

    let version_client = client.version()
    let task_client = client.tasks()
    ...
```