### PR TITLE
Group release notes by crate

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  categories:
+    - title: Runc crate
+      labels:
+        - C-runc
+    - title: Runc shim crate
+      labels:
+        - C-runc-shim
+    - title: Shim crate
+      labels:
+        - C-shim
+    - title: Shim protos crate
+      labels:
+        - C-shim-protos
+    - title: Snapshots crate
+      labels:
+        - C-snapshots
+    - title: Client crate
+      labels:
+        - C-client
+    - title: Logging crate
+      labels:
+        - C-logging
+    - title: Other changes
+      labels:
+        - T-CI
+        - T-docs


### PR DESCRIPTION
Adding a config to group PRs by label for the Github's release notes generator.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes


cc: @Mossaka @jsturtevant 