### PR TITLE
MAINTAINERS : Add James Sturtevant to reviewers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,3 +7,4 @@
 # REVIEWERS
 # GitHub ID, Name, Email address
 "Burning1020","Zhang Tianyang","burning9699@gmail.com"
+"jsturtevant","James Sturtevant","jstur@microsoft.com"


### PR DESCRIPTION
James has been super helpful in [maintaining](https://github.com/containerd/rust-extensions/issues?q=author%3Ajsturtevant) the project (and adding new features),
so I'd like to invite @jsturtevant as a reviewer in `rust-extensions` repo.

Needs explicit LGTM from @jsturtevant 

I'd also like to get a few LGTMs from the Core Committers for visibility.