### PR TITLE
Handle cgroup v1 or v2 to enable resource updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           GOPROXY: direct
           TEST_RUNTIME: "io.containerd.runc.v2-rs"
           TESTFLAGS_PARALLEL: 1
-          EXTRA_TESTFLAGS: "-no-criu -test.skip='(TestContainerPTY|TestContainerExecLargeOutputWithTTY|TestTaskUpdate|TestTaskResize)'"
+          EXTRA_TESTFLAGS: "-no-criu -test.skip='(TestContainerPTY|TestContainerExecLargeOutputWithTTY)'"
           TESTFLAGS_RACE: "-race"
         run: |
           # https://github.com/containerd/rust-extensions/issues/147#issuecomment-1684553369


### PR DESCRIPTION
Part of #122 

This test was failing in 22.04  because it has cgroups v2.  This follows same pattern as the metrics to select either v1 or v2.

