### PR TITLE
Add Windows statistics protobuf pacakge

### DIFF
--- a/crates/shim-protos/build.rs
+++ b/crates/shim-protos/build.rs
@@ -45,6 +45,12 @@ fn main() {
     );
 
     genmodule(
+        "stats",
+        &["vendor/microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats/stats.proto"],
+        false,
+    );
+
+    genmodule(
         "events",
         &[
             "vendor/github.com/containerd/containerd/api/types/mount.proto",

--- a/crates/shim-protos/src/lib.rs
+++ b/crates/shim-protos/src/lib.rs
@@ -71,6 +71,7 @@ pub mod events;
 mod sandbox;
 pub mod shim;
 pub mod types;
+pub mod windows;
 
 /// Includes event names shims can publish to containerd.
 pub mod topics;

--- a/crates/shim-protos/src/windows.rs
+++ b/crates/shim-protos/src/windows.rs
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+pub mod stats {
+    include!(concat!(env!("OUT_DIR"), "/stats/stats.rs"));
+}
+
+pub mod metrics {
+    pub use crate::cgroups::metrics::{file_descriptor, Metrics};
+}

--- a/crates/shim-protos/vendor/README.md
+++ b/crates/shim-protos/vendor/README.md
@@ -6,3 +6,5 @@ Proto files are copy-pasted directly from upstream repos:
 + https://github.com/containerd/containerd
 + https://github.com/protocolbuffers/protobuf
 + https://github.com/gogo/protobuf
++ https://github.com/containerd/cgroups
++ https://github.com/microsoft/hcsshim

--- a/crates/shim-protos/vendor/github.com/containerd/cgroups/v3/cgroup1/stats/metrics.proto
+++ b/crates/shim-protos/vendor/github.com/containerd/cgroups/v3/cgroup1/stats/metrics.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package io.containerd.cgroups.v1;
+
+option go_package = "github.com/containerd/cgroups/cgroup1/stats";
+
+message Metrics {
+	repeated HugetlbStat hugetlb = 1;
+	PidsStat pids = 2;
+	CPUStat cpu = 3;
+	MemoryStat memory = 4;
+	BlkIOStat blkio = 5;
+	RdmaStat rdma = 6;
+	repeated NetworkStat network = 7;
+	CgroupStats cgroup_stats = 8;
+	MemoryOomControl memory_oom_control = 9;
+}
+
+message HugetlbStat {
+	uint64 usage = 1;
+	uint64 max = 2;
+	uint64 failcnt = 3;
+	string pagesize = 4;
+}
+
+message PidsStat {
+	uint64 current = 1;
+	uint64 limit = 2;
+}
+
+message CPUStat {
+	CPUUsage usage = 1;
+	Throttle throttling = 2;
+}
+
+message CPUUsage {
+	// values in nanoseconds
+	uint64 total = 1;
+	uint64 kernel = 2;
+	uint64 user = 3;
+	repeated uint64 per_cpu = 4;
+
+}
+
+message Throttle {
+	uint64 periods = 1;
+	uint64 throttled_periods = 2;
+	uint64 throttled_time = 3;
+}
+
+message MemoryStat {
+	uint64 cache = 1;
+	uint64 rss = 2;
+	uint64 rss_huge = 3;
+	uint64 mapped_file = 4;
+	uint64 dirty = 5;
+	uint64 writeback = 6;
+	uint64 pg_pg_in = 7;
+	uint64 pg_pg_out = 8;
+	uint64 pg_fault = 9;
+	uint64 pg_maj_fault = 10;
+	uint64 inactive_anon = 11;
+	uint64 active_anon = 12;
+	uint64 inactive_file = 13;
+	uint64 active_file = 14;
+	uint64 unevictable = 15;
+	uint64 hierarchical_memory_limit = 16;
+	uint64 hierarchical_swap_limit = 17;
+	uint64 total_cache = 18;
+	uint64 total_rss = 19;
+	uint64 total_rss_huge = 20;
+	uint64 total_mapped_file = 21;
+	uint64 total_dirty = 22;
+	uint64 total_writeback = 23;
+	uint64 total_pg_pg_in = 24;
+	uint64 total_pg_pg_out = 25;
+	uint64 total_pg_fault = 26;
+	uint64 total_pg_maj_fault = 27;
+	uint64 total_inactive_anon = 28;
+	uint64 total_active_anon = 29;
+	uint64 total_inactive_file = 30;
+	uint64 total_active_file = 31;
+	uint64 total_unevictable = 32;
+	MemoryEntry usage = 33;
+	MemoryEntry swap = 34;
+	MemoryEntry kernel = 35;
+	MemoryEntry kernel_tcp = 36;
+
+}
+
+message MemoryEntry {
+	uint64 limit = 1;
+	uint64 usage = 2;
+	uint64 max = 3;
+	uint64 failcnt = 4;
+}
+
+message MemoryOomControl {
+	uint64 oom_kill_disable = 1;
+	uint64 under_oom = 2;
+	uint64 oom_kill = 3;
+}
+
+message BlkIOStat {
+	repeated BlkIOEntry io_service_bytes_recursive = 1;
+	repeated BlkIOEntry io_serviced_recursive = 2;
+	repeated BlkIOEntry io_queued_recursive = 3;
+	repeated BlkIOEntry io_service_time_recursive = 4;
+	repeated BlkIOEntry io_wait_time_recursive = 5;
+	repeated BlkIOEntry io_merged_recursive = 6;
+	repeated BlkIOEntry io_time_recursive = 7;
+	repeated BlkIOEntry sectors_recursive = 8;
+}
+
+message BlkIOEntry {
+	string op = 1;
+	string device = 2;
+	uint64 major = 3;
+	uint64 minor = 4;
+	uint64 value = 5;
+}
+
+message RdmaStat {
+	repeated RdmaEntry current = 1;
+	repeated RdmaEntry limit = 2;
+}
+
+message RdmaEntry {
+	string device = 1;
+	uint32 hca_handles = 2;
+	uint32 hca_objects = 3;
+}
+
+message NetworkStat {
+	string name = 1;
+	uint64 rx_bytes = 2;
+	uint64 rx_packets = 3;
+	uint64 rx_errors  = 4;
+	uint64 rx_dropped = 5;
+	uint64 tx_bytes = 6;
+	uint64 tx_packets = 7;
+	uint64 tx_errors = 8;
+	uint64 tx_dropped = 9;
+}
+
+// CgroupStats exports per-cgroup statistics.
+message CgroupStats {
+	// number of tasks sleeping
+	uint64 nr_sleeping = 1;
+	// number of tasks running
+	uint64 nr_running = 2;
+	// number of tasks in stopped state
+	uint64 nr_stopped = 3;
+	// number of tasks in uninterruptible state
+	uint64 nr_uninterruptible = 4;
+	// number of tasks waiting on IO
+	uint64 nr_io_wait = 5;
+}

--- a/crates/shim-protos/vendor/microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats/stats.proto
+++ b/crates/shim-protos/vendor/microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats/stats.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package containerd.runhcs.stats.v1;
+
+import "google/protobuf/timestamp.proto";
+import "github.com/containerd/cgroups/v3/cgroup1/stats/metrics.proto";
+
+option go_package = "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats;stats";
+
+message Statistics {
+	oneof container {
+		WindowsContainerStatistics windows = 1;
+		io.containerd.cgroups.v1.Metrics linux = 2;
+	}
+	VirtualMachineStatistics vm = 3;
+}
+
+message WindowsContainerStatistics {
+	google.protobuf.Timestamp timestamp = 1;
+	google.protobuf.Timestamp container_start_time = 2;
+	uint64 uptime_ns = 3;
+	WindowsContainerProcessorStatistics processor = 4;
+	WindowsContainerMemoryStatistics memory = 5;
+	WindowsContainerStorageStatistics storage = 6;
+}
+
+message WindowsContainerProcessorStatistics {
+	uint64 total_runtime_ns = 1;
+	uint64 runtime_user_ns = 2;
+	uint64 runtime_kernel_ns = 3;
+}
+
+message WindowsContainerMemoryStatistics {
+	uint64 memory_usage_commit_bytes = 1;
+	uint64 memory_usage_commit_peak_bytes = 2;
+	uint64 memory_usage_private_working_set_bytes = 3;
+}
+
+message WindowsContainerStorageStatistics {
+	uint64 read_count_normalized = 1;
+	uint64 read_size_bytes = 2;
+	uint64 write_count_normalized = 3;
+	uint64 write_size_bytes = 4;
+}
+
+message VirtualMachineStatistics {
+	VirtualMachineProcessorStatistics processor = 1;
+	VirtualMachineMemoryStatistics memory = 2;
+}
+
+message VirtualMachineProcessorStatistics {
+	uint64 total_runtime_ns = 1;
+}
+
+message VirtualMachineMemoryStatistics {
+	uint64 working_set_bytes = 1;
+	uint32 virtual_node_count = 2;
+	VirtualMachineMemory vm_memory = 3;
+}
+
+message VirtualMachineMemory {
+	int32 available_memory = 1;
+	int32 available_memory_buffer = 2;
+	uint64 reserved_memory = 3;
+	uint64 assigned_memory = 4;
+	bool slp_active = 5;
+	bool balancing_enabled = 6;
+	bool dm_operation_in_progress = 7;
+}


### PR DESCRIPTION
This adds the necessary protobuff files and configures it so we can generate ttrpc `stats` endpoint.  The import for a package would look like: 

```
use containerd_shim_protos::windows::stats::{Statistics, WindowsContainerStatistics}
```