### PR TITLE
Bump the version for shim protos and containerd-shim

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -39,5 +39,5 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 
-containerd-shim = { path = "../shim", version = "0.4.0", features = ["async"] }
+containerd-shim = { path = "../shim", version = "0.5.0", features = ["async"] }
 runc = { path = "../runc", version = "0.2.0", features = ["async"] }

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-protos"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
 description = "TTRPC bindings for containerd shim interfaces"
 keywords = ["containerd", "shim", "containers", "ttrpc", "client"]

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
 keywords = ["containerd", "shim", "containers"]
 description = "containerd shim extension"
@@ -38,7 +38,7 @@ prctl = "1.0.0"
 page_size = "0.6.0"
 regex = "1"
 
-containerd-shim-protos = { path = "../shim-protos", version = "0.4.0" }
+containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
 
 async-trait = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }


### PR DESCRIPTION
Create a release for the following features:

- https://github.com/containerd/rust-extensions/pull/163
- https://github.com/containerd/rust-extensions/pull/177
- https://github.com/containerd/rust-extensions/pull/178

/cc @Mossaka 