### PR TITLE
Fix CI

### DIFF
--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "containerd-shim-protos"
 version = "0.5.0"
-authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
+authors = [
+    "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+    "The containerd Authors",
+]
 description = "TTRPC bindings for containerd shim interfaces"
 keywords = ["containerd", "shim", "containers", "ttrpc", "client"]
 categories = ["api-bindings"]
@@ -13,7 +16,12 @@ homepage.workspace = true
 
 [dependencies]
 protobuf = "3.1"
-ttrpc = "0.8.0" 
+
+# Quickfix to make CI green.
+# 0.8.1 introduces a breaking change in the API.
+# https://github.com/containerd/ttrpc-rust/pull/197
+# https://github.com/containerd/ttrpc-rust/pull/209
+ttrpc = "=0.8.0"
 async-trait = { version = "0.1.48", optional = true }
 
 [build-dependencies]
@@ -22,7 +30,9 @@ ttrpc-codegen = "0.4"
 [dev-dependencies]
 ctrlc = { version = "3.0", features = ["termination"] }
 log = "0.4"
-simple_logger = { version = "4.0", default-features = false, features = ["stderr"] }
+simple_logger = { version = "4.0", default-features = false, features = [
+    "stderr",
+] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]


### PR DESCRIPTION
Dependabot opened a bunch of PRs, which are failing because of breaking change in ttrpc 0.8.1 (https://github.com/containerd/ttrpc-rust/pull/197).
This PR pins ttrpc crate to 0.8.0 to make CI green until we figure out the fix.