### PR TITLE
chore: Standardize Cargo.toml files, enable more workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-    "crates/client",
-    "crates/logging",
-    "crates/shim-protos",
-    "crates/shim",
-    "crates/snapshots",
-    "crates/runc",
-    "crates/runc-shim",
+  "crates/client",
+  "crates/logging",
+  "crates/runc",
+  "crates/runc-shim",
+  "crates/shim",
+  "crates/shim-protos",
+  "crates/snapshots",
 ]
 
 [profile.release]
@@ -24,14 +24,21 @@ edition = "2021"
 
 # Common dependencies for all crates
 [workspace.dependencies]
-tokio = "1.26"
-tower = "0.4"
-
-tonic = "0.10"
-tonic-build = "0.10"
-
-prost = "0.12"
-prost-types = "0.12"
-
 async-trait = "0.1.52"
 futures = "0.3.19"
+libc = "0.2.112"
+log = "0.4"
+nix = "0.26"
+oci-spec = "0.6"
+os_pipe = "1.1"
+prost = "0.12"
+prost-types = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+time = { version = "0.3.7", features = ["serde", "std"] }
+tokio = "1.26"
+tonic = "0.10"
+tonic-build = "0.10"
+tower = "0.4"
+uuid = { version = "1.0", features = ["v4"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -2,8 +2,8 @@
 name = "containerd-client"
 version = "0.4.0"
 authors = [
-    "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
-    "The containerd Authors",
+  "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+  "The containerd Authors",
 ]
 description = "GRPC bindings to containerd APIs"
 keywords = ["containerd", "client", "grpc", "containers"]
@@ -14,11 +14,19 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[[example]]
+name = "container"
+path = "examples/container.rs"
+
+[[example]]
+name = "version"
+path = "examples/version.rs"
+
 [dependencies]
-tonic.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 tokio = { workspace = true, optional = true }
+tonic.workspace = true
 tower = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "containerd-shim-logging"
 version = "0.1.1"
-authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
+authors = [
+  "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+  "The containerd Authors"
+]
 description = "Logger extension for containerd v2 runtime"
 keywords = ["containerd", "shim", "containers"]
+categories = ["api-bindings", "asynchronous"]
 
 edition.workspace = true
 license.workspace = true

--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -6,8 +6,9 @@ authors = [
     "Tianyang Zhang <burning9699@gmail.com>",
     "The containerd Authors",
 ]
-keywords = ["containerd", "shim", "containers"]
 description = "Rust implementation of containerd's runc v2 shim runtime"
+keywords = ["containerd", "shim", "containers"]
+categories = ["api-bindings", "asynchronous"]
 
 edition.workspace = true
 license.workspace = true
@@ -24,20 +25,19 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-log = "0.4"
-nix = "0.26"
-libc = "0.2.95"
-time = { version = "0.3.7", features = ["serde", "std"] }
-serde = { version = "1.0.133", features = ["derive"] }
-serde_json = "1.0.74"
-oci-spec = "0.6.0"
+containerd-shim = { path = "../shim", version = "0.5.0", features = ["async"] }
 crossbeam = "0.8.1"
-uuid = { version = "1.0.0", features = ["v4"] }
+libc.workspace = true
+log.workspace = true
+nix.workspace = true
+oci-spec.workspace = true
+runc = { path = "../runc", version = "0.2.0", features = ["async"] }
+serde.workspace = true
+serde_json.workspace = true
+time.workspace = true
+uuid.workspace = true
 
 # Async dependencies
-async-trait = { workspace = true }
+async-trait.workspace = true
+futures.workspace = true
 tokio = { workspace = true, features = ["full"] }
-futures = { workspace = true }
-
-containerd-shim = { path = "../shim", version = "0.5.0", features = ["async"] }
-runc = { path = "../runc", version = "0.2.0", features = ["async"] }

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "runc"
 version = "0.2.0"
-authors = ["Yuna Tomida <ytomida.mmm@gmail.com>", "The containerd Authors"]
-keywords = ["containerd", "containers", "runc"]
+authors = [
+  "Yuna Tomida <ytomida.mmm@gmail.com>",
+  "The containerd Authors",
+]
 description = "A crate for consuming the runc binary in your Rust applications"
+keywords = ["containerd", "containers", "runc"]
+categories = ["api-bindings", "asynchronous"]
 
 edition.workspace = true
 license.workspace = true
@@ -13,24 +17,23 @@ homepage.workspace = true
 [features]
 async = ["tokio", "async-trait", "futures", "tokio-pipe"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-libc = "0.2.112"
-log = "0.4.14"
-nix = "0.26"
-oci-spec = "0.6.0"
+libc.workspace = true
+log.workspace = true
+nix.workspace = true
+oci-spec.workspace = true
+os_pipe.workspace = true
 path-absolutize = "3.0.11"
 rand = "0.8.4"
-serde = { version = "1.0.133", features = ["derive"] }
-serde_json = "1.0.74"
+serde.workspace = true
+serde_json.workspace = true
 tempfile = "3.6.0"
-thiserror = "1.0.30"
-time = { version = "0.3.7", features = ["serde", "std"] }
-uuid = { version = "1.0.0", features = ["v4"] }
-os_pipe = "1.0.0"
+thiserror.workspace = true
+time.workspace = true
+uuid.workspace = true
 
 # Async dependencies
-tokio = { workspace = true, features = ["full"], optional = true }
 async-trait = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 tokio-pipe = { version="0.2.10", optional = true }

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -2,38 +2,17 @@
 name = "containerd-shim-protos"
 version = "0.5.0"
 authors = [
-    "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
-    "The containerd Authors",
+  "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+  "The containerd Authors",
 ]
 description = "TTRPC bindings for containerd shim interfaces"
 keywords = ["containerd", "shim", "containers", "ttrpc", "client"]
-categories = ["api-bindings"]
+categories = ["api-bindings", "asynchronous"]
 
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-
-[dependencies]
-protobuf = "3.1"
-
-# Quickfix to make CI green.
-# 0.8.1 introduces a breaking change in the API.
-# https://github.com/containerd/ttrpc-rust/pull/197
-# https://github.com/containerd/ttrpc-rust/pull/209
-ttrpc = "=0.8.0"
-async-trait = { version = "0.1.48", optional = true }
-
-[build-dependencies]
-ttrpc-codegen = "0.4"
-
-[dev-dependencies]
-ctrlc = { version = "3.0", features = ["termination"] }
-log = "0.4"
-simple_logger = { version = "4.0", default-features = false, features = [
-    "stderr",
-] }
-tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = []
@@ -66,3 +45,21 @@ required-features = ["async"]
 name = "shim-proto-connect-async"
 path = "examples/connect-async.rs"
 required-features = ["async"]
+
+[dependencies]
+async-trait = { version = "0.1.48", optional = true }
+protobuf = "3.1"
+# Quickfix to make CI green.
+# 0.8.1 introduces a breaking change in the API.
+# https://github.com/containerd/ttrpc-rust/pull/197
+# https://github.com/containerd/ttrpc-rust/pull/209
+ttrpc = "=0.8.0"
+
+[build-dependencies]
+ttrpc-codegen = "0.4"
+
+[dev-dependencies]
+ctrlc = { version = "3.0", features = ["termination"] }
+log.workspace = true
+simple_logger = { version = "4.0", default-features = false, features = ["stderr"]}
+tokio = { workspace = true, features = ["full"] }

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "containerd-shim"
 version = "0.5.0"
-authors = ["Maksym Pavlenko <pavlenko.maksym@gmail.com>", "The containerd Authors"]
-keywords = ["containerd", "shim", "containers"]
+authors = [
+  "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+  "The containerd Authors",
+]
 description = "containerd shim extension"
+keywords = ["containerd", "shim", "containers"]
+categories = ["api-bindings", "asynchronous"]
 
 edition.workspace = true
 license.workspace = true
@@ -11,7 +15,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-async = ["tokio", "containerd-shim-protos/async", "async-trait", "futures", "signal-hook-tokio"]
+async = [
+  "async-trait",
+  "containerd-shim-protos/async",
+  "futures",
+  "signal-hook-tokio",
+  "tokio",
+]
 
 [[example]]
 name = "skeleton_async"
@@ -22,27 +32,26 @@ name = "windows-log-reader"
 path = "examples/windows_log_reader.rs"
 
 [dependencies]
-go-flag = "0.1.0"
-thiserror = "1.0"
-log = { version = "0.4", features = ["std"] }
-libc = "0.2.95"
-nix = "0.26"
-lazy_static = "1.4.0"
-time = { version = "0.3.7", features = ["serde", "std"] }
-serde_json = "1.0.78"
-serde_derive = "1.0.136"
-serde = "1.0.136"
-signal-hook = "0.3.13"
-oci-spec = "0.6.0"
-prctl = "1.0.0"
-page_size = "0.6.0"
-
 containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
+go-flag = "0.1.0"
+lazy_static = "1.4.0"
+libc.workspace = true
+log = { workspace = true, features = ["std"]}
+nix.workspace = true
+oci-spec.workspace = true
+page_size = "0.6.0"
+prctl = "1.0.0"
+signal-hook = "0.3.13"
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time.workspace = true
 
+# Async dependencies
 async-trait = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["full"], optional = true }
 futures = { workspace = true, optional = true}
 signal-hook-tokio = { version = "0.3.1", optional = true, features = ["futures-v0_3"]}
+tokio = { workspace = true, features = ["full"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.2.9"
@@ -51,9 +60,17 @@ cgroups-rs = "0.2.9"
 command-fds = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = {version = "0.48.0", features = ["Win32_Foundation","Win32_System_WindowsProgramming","Win32_System_Console", "Win32_System_Pipes","Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Threading"]}
 mio = { version = "0.8", features = ["os-ext", "os-poll"] }
-os_pipe = "1.1.3"
+os_pipe.workspace = true
+windows-sys = {version = "0.48.0", features = [
+  "Win32_Foundation",
+  "Win32_System_WindowsProgramming",
+  "Win32_System_Console",
+  "Win32_System_Pipes",
+  "Win32_Security",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Threading",
+  ]}
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile = "3.6"

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -2,12 +2,12 @@
 name = "containerd-snapshots"
 version = "0.3.0"
 authors = [
-    "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
-    "The containerd Authors",
+  "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
+  "The containerd Authors",
 ]
+description = "Remote snapshotter extension for containerd"
 keywords = ["containerd", "server", "grpc", "containers"]
 categories = ["api-bindings", "asynchronous"]
-description = "Remote snapshotter extension for containerd"
 
 edition.workspace = true
 license.workspace = true
@@ -15,21 +15,21 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-thiserror = "1.0"
-tonic.workspace = true
-prost.workspace = true
-prost-types.workspace = true
-tokio = { workspace = true, features = ["sync"] }
-tokio-stream = "0.1.8"
-serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.3"
 futures.workspace = true
 pin-utils = "0.1.0"
+prost.workspace = true
+prost-types.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tonic.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = "0.1.8"
 
 [dev-dependencies]
-log = "0.4"
 async-stream = "0.3.2"
 futures.workspace = true
+log.workspace = true
 simple_logger = { version = "4.0", default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
- Attempt to unify and standardize the Cargo.toml files used through the project
	- Order the dependencies alphabetically; the async deps have been kept as a separate section but happy to include this in the mix as well
	- In the future it would be nice to use `cargo-sort` and have a CI check to keep it consistent but currently it [lacks support for workspace inheritence](https://github.com/DevinR528/cargo-sort/issues/54)
	- Hoist up dependencies to the main Cargo.toml and use the workspace dependency inheritance to align versions
	- Add `keywords` and `categories` sections where missing
-  Add the client examples to its Cargo.toml
