### PR TITLE
deps: Remove the use of the `regex` crate

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -36,7 +36,6 @@ signal-hook = "0.3.13"
 oci-spec = "0.6.0"
 prctl = "1.0.0"
 page_size = "0.6.0"
-regex-lite = "0.1"
 
 containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
 

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -36,7 +36,7 @@ signal-hook = "0.3.13"
 oci-spec = "0.6.0"
 prctl = "1.0.0"
 page_size = "0.6.0"
-regex = "1"
+regex-lite = "0.1"
 
 containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
 

--- a/crates/shim/src/mount.rs
+++ b/crates/shim/src/mount.rs
@@ -29,7 +29,7 @@ use log::error;
 use nix::mount::{mount, MsFlags};
 #[cfg(target_os = "linux")]
 use nix::unistd::{fork, ForkResult};
-use regex::Regex;
+use regex_lite::Regex;
 
 use crate::error::{Error, Result};
 #[cfg(not(feature = "async"))]
@@ -273,7 +273,7 @@ fn longest_common_prefix(dirs: &[String]) -> Option<String> {
 }
 
 // NOTE: the snapshot id is based on digits.
-// in order to avoid to get snapshots/x, shoule be back to parent dir.
+// in order to avoid to get snapshots/x, should be back to parent dir.
 // however, there is assumption that the common dir is ${root}/io.containerd.v1.overlayfs/snapshots.
 #[cfg(target_os = "linux")]
 fn trim_flawed_dir(s: &str) -> String {

--- a/crates/shim/src/mount.rs
+++ b/crates/shim/src/mount.rs
@@ -267,19 +267,7 @@ fn longest_common_prefix(dirs: &[String]) -> &str {
 // however, there is assumption that the common dir is ${root}/io.containerd.v1.overlayfs/snapshots.
 #[cfg(target_os = "linux")]
 fn trim_flawed_dir(s: &str) -> String {
-    match s.ends_with('/') {
-        true => s.to_owned(),
-        false => {
-            // Iterate in reverse order to find the last '/', then return string in correct order
-            s.chars()
-                .rev()
-                .skip_while(|x| *x != '/')
-                .collect::<Vec<char>>()
-                .iter()
-                .rev()
-                .collect::<String>()
-        }
-    }
+    s[0..s.rfind('/').unwrap_or(0) + 1].to_owned()
 }
 
 #[cfg(target_os = "linux")]
@@ -619,6 +607,8 @@ mod tests {
     #[test]
     fn test_trim_flawed_dir() {
         let mut tcases: Vec<(&str, String)> = Vec::new();
+        tcases.push(("/", "/".to_string()));
+        tcases.push(("/foo", "/".to_string()));
         tcases.push(("/.foo-_bar/foo", "/.foo-_bar/".to_string()));
         tcases.push(("/.foo-_bar/foo/", "/.foo-_bar/foo/".to_string()));
         tcases.push(("/.foo-_bar/foo/bar", "/.foo-_bar/foo/".to_string()));


### PR DESCRIPTION
- Instead of using the `regex` crate to ensure the path ends at the correct `/` which is a bit heavy handed for this use case, it has been replaced with an iterator based implementation 
- Simplify longest common prefix logic -  this was pinched from [here](https://users.rust-lang.org/t/is-this-code-idiomatic/51798/4), the original logic seemed a bit verbose