### PR TITLE
ci: Download containerd binaries from GitHub release archives for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,43 +89,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        containerd: [v1.6.21, v1.7.1]
+        containerd: [1.6.21, 1.7.1]
 
     steps:
       - name: Checkout extensions
         uses: actions/checkout@v4
+
+      - name: Download containerd release v${{ matrix.containerd }} archive
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: "containerd/containerd"
+          tag: v${{ matrix.containerd }}
+          fileName: "containerd-${{ matrix.containerd }}-linux-amd64.tar.gz"
+          extract: true
+
+      - name: Add containerd binaries to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Checkout containerd
         uses: actions/checkout@v4
         with:
           repository: containerd/containerd
           path: src/github.com/containerd/containerd
-          ref: ${{ matrix.containerd }}
-
-      - name: Get Go Version
-        run: |
-          go_version=$(awk -F': ' '/GO_VERSION/ {gsub(/["'\'']/, "", $2); print $2; exit}' .github/workflows/release.yml)
-          echo "GO_VERSION=$go_version" >> $GITHUB_ENV
-        working-directory: src/github.com/containerd/containerd
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Install containerd
-        env:
-          GOFLAGS: -modcacherw
-          CGO_ENABLED: 1
-        run: |
-          # Install containerd dependencies first
-          sudo apt-get install -y gperf
-          sudo -E PATH=$PATH script/setup/install-seccomp
-          sudo -E PATH=$PATH script/setup/install-runc
-          sudo -E PATH=$PATH script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
-          # Install containerd
-          sudo -E PATH=$PATH make bin/containerd GO_BUILD_FLAGS="-mod=vendor" BUILDTAGS="no_btrfs no_devmapper"
-          sudo -E PATH=$PATH install bin/containerd /usr/local/bin/
-        working-directory: src/github.com/containerd/containerd
+          ref: v${{ matrix.containerd }}
 
       - name: Install shim
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,20 @@ jobs:
       - name: Checkout extensions
         uses: actions/checkout@v4
 
-      - name: Download containerd release v${{ matrix.containerd }} archive
-        uses: robinraju/release-downloader@v1.8
-        with:
-          repository: "containerd/containerd"
-          tag: v${{ matrix.containerd }}
-          fileName: "containerd-${{ matrix.containerd }}-linux-amd64.tar.gz"
-          extract: true
+      - name: Download containerd archive
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v${{ matrix.containerd }} \
+            --repo containerd/containerd \
+            --pattern 'containerd-${{ matrix.containerd }}-linux-amd64.tar.gz' \
+            --output containerd.tar.gz
 
-      - name: Add containerd binaries to PATH
-        run: echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Extract containerd binaries to $HOME/.local/bin
+        run: |
+          mkdir -p $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          tar -xf containerd.tar.gz -C $HOME/.local
 
       - name: Checkout containerd
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        containerd: [1.6.21, 1.7.1]
+        containerd: [v1.6.21, v1.7.1]
 
     steps:
       - name: Checkout extensions
@@ -99,9 +99,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download v${{ matrix.containerd }} \
+          gh release download ${{ matrix.containerd }} \
             --repo containerd/containerd \
-            --pattern 'containerd-${{ matrix.containerd }}-linux-amd64.tar.gz' \
+            --pattern 'containerd-1.*-linux-amd64.tar.gz' \
             --output containerd.tar.gz
 
       - name: Extract containerd binaries to $HOME/.local/bin
@@ -115,7 +115,7 @@ jobs:
         with:
           repository: containerd/containerd
           path: src/github.com/containerd/containerd
-          ref: v${{ matrix.containerd }}
+          ref: ${{ matrix.containerd }}
 
       - name: Install shim
         run: |


### PR DESCRIPTION
- Download containerd binaries from GitHub release archives for integration tests

When investigating the merge queue integration failures on https://github.com/containerd/rust-extensions/pull/200 I came across https://github.com/containerd/rust-extensions/issues/147 and the discussion around using the release archives instead of building in the pipeline. I created a quick fork in a separate org and pushed up some changes to validate since this won't run the changes on my PR here, it will only use `main` (its Github security feature). So here is the results of these changes https://github.com/clowdhaus/rust-extensions/actions/runs/6267161577