### PR TITLE
Use log format similar to containerd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ prost-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-time = { version = "0.3.7", features = ["serde", "std"] }
+time = { version = "0.3.29", features = ["serde", "std", "formatting"] }
 tokio = "1.26"
 tonic = "0.10"
 tonic-build = "0.10"


### PR DESCRIPTION
Currently a shim default logs don't have time in it which can make it hard to debug timing issues:

```
[INFO] starting instance: f117ec9ffa52b4a5cc2550cc4ff301b645b83289f927ae4ddaeba36fd5d6aab0
[INFO] cgroup manager V2 will be used
```

this PR sets up the log format so that it is in same format as containerd (not including `msg` as that can be left to the implementor)

```
#example containerd log
time="2023-10-04T00:06:36.183411295Z" level=info msg="StartContainer for \"bbfbebc5259e9bc6ef12b8749e9c1760aac461db5ae506fe8c18b645c136cb4a\""

# example shim after change
time="2023-10-04T00:06:36.185484399Z" level=info instantiating instance
time="2023-10-04T00:06:36.185818899Z" level=info getting start function
```