### PR TITLE
Add support for structured logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 async-trait = "0.1.52"
 futures = "0.3.19"
 libc = "0.2.112"
-log = "0.4"
+log = {version = "0.4.2", features=["kv_unstable"]}
 nix = "0.27"
 oci-spec = "0.6"
 os_pipe = "1.1"

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -37,7 +37,7 @@ containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
 go-flag = "0.1.0"
 lazy_static = "1.4.0"
 libc.workspace = true
-log = { workspace = true, features = ["std"] }
+log = { workspace = true, features = ["std", "kv_unstable" ] }
 nix = { workspace = true, features = [
   "ioctl",
   "fs",

--- a/crates/shim/src/logger.rs
+++ b/crates/shim/src/logger.rs
@@ -70,7 +70,13 @@ impl<'kvs> Visitor<'kvs> for SimpleWriteVistor {
 }
 
 impl SimpleWriteVistor {
-    fn as_str(&self) -> &str {
+    pub(crate) fn new() -> SimpleWriteVistor {
+        SimpleWriteVistor {
+            key_values: String::new(),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
         &self.key_values
     }
 }
@@ -85,9 +91,7 @@ impl log::Log for FifoLogger {
             let mut guard = self.file.lock().unwrap();
 
             // collect key_values but don't fail if error parsing
-            let mut writer = SimpleWriteVistor {
-                key_values: String::new(),
-            };
+            let mut writer = SimpleWriteVistor::new();
             let _ = record.key_values().visit(&mut writer);
 
             // The logger server may have temporarily shutdown, ignore the error instead of panic.

--- a/crates/shim/src/sys/windows/named_pipe_logger.rs
+++ b/crates/shim/src/sys/windows/named_pipe_logger.rs
@@ -85,13 +85,11 @@ impl log::Log for NamedPipeLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             // collect key_values but don't fail if error parsing
-            let mut writer = logger::SimpleWriteVistor {
-                keyvalues: String::new(),
-            };
+            let mut writer = logger::SimpleWriteVistor::new();
             let _ = record.key_values().visit(&mut writer);
 
             let message = format!(
-                "time=\"{}\" level={}{} {}\n",
+                "time=\"{}\" level={}{} msg=\"{}\"\n",
                 logger::rfc3339_formated(),
                 record.level().as_str().to_lowercase(),
                 writer.as_str(),
@@ -190,11 +188,11 @@ mod tests {
         logger.log(&record);
         logger.flush();
 
-        let buf = read_message(&mut client, 53);
+        let buf = read_message(&mut client, 73);
         let message = std::str::from_utf8(&buf).unwrap();
         assert!(message.starts_with("time=\""), "message was: {:?}", message);
         assert!(
-            message.ends_with("level=info key=\"1\" b=\"2\" msg=\"hello\"\n"),
+            message.contains("level=info key=\"1\" b=\"2\" msg=\"hello\"\n"),
             "message was: {:?}",
             message
         );


### PR DESCRIPTION
This is a follow up to #210.  

Example usage would be:

```
log::info!(target: "wasmtime", key1 = "test it"; "setting up wasi!!");
```

with the output

```
time="2023-10-06T21:49:05.767158934Z" level=info msg="calling start function"
time="2023-10-06T21:49:05.767242837Z" level=info key1="test it" msg="setting up wasi!!"
time="2023-10-06T21:49:05.767259938Z" level=info msg="waiting for instance: testwasm"
```

**Question**: Should this be behind a feature flag?  The functionality is in `log` crate behind `kv_unstable`.  The major issue would be that the api might change but it is pretty small api that is being used here and it is being used in projects like https://github.com/iorust/structured-logger
