### PR TITLE
Updates cgroup rs to latest version

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -63,7 +63,7 @@ signal-hook-tokio = { version = "0.3.1", optional = true, features = [
 tokio = { workspace = true, features = ["full"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-cgroups-rs = "0.2.9"
+cgroups-rs = "0.3.3"
 
 [target.'cfg(unix)'.dependencies]
 command-fds = "0.2.1"

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -302,7 +302,7 @@ mod tests {
         let h = hierarchies::auto();
 
         // create cgroup path first
-        let cg = Cgroup::new(h, path);
+        let cg = Cgroup::new(h, path).unwrap();
 
         let pid = std::process::id();
         add_task_to_cgroup(path, pid).unwrap();
@@ -310,7 +310,7 @@ mod tests {
         assert!(cg.tasks().contains(&cg_id));
 
         // remove cgroup as possible
-        cg.remove_task(cg_id);
+        cg.remove_task(cg_id).unwrap();
         cg.delete().unwrap()
     }
 

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -64,7 +64,7 @@ pub fn add_task_to_cgroup(path: &str, pid: u32) -> Result<()> {
     let path = path.trim_start_matches('/');
 
     Cgroup::load(h, path)
-        .add_task(CgroupPid::from(pid as u64))
+        .add_task_by_tgid(CgroupPid::from(pid as u64))
         .map_err(other_error!(e, "add task to cgroup"))
 }
 
@@ -310,7 +310,7 @@ mod tests {
         assert!(cg.tasks().contains(&cg_id));
 
         // remove cgroup as possible
-        cg.remove_task(cg_id).unwrap();
+        cg.remove_task_by_tgid(cg_id).unwrap();
         cg.delete().unwrap()
     }
 


### PR DESCRIPTION
Fixes #169

In cgroupv2 we should use the `cgroups.proc` file when adding a process (https://www.man7.org/linux/man-pages/man7/cgroups.7.html).  The `add_tasks` function was writing to the `cgroup.threads` file which is only available when in threaded mode on v2.  In either case our intent is to add the process not the individual threads to we should use `add_task_by_tgid`. See https://github.com/kata-containers/cgroups-rs/pull/104 for when this was added