### PR TITLE
Create v0.6.0 release of containerd-shim and shim-protos

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-containerd-shim = { path = "../shim", version = "0.5.0", features = ["async"] }
+containerd-shim = { path = "../shim", version = "0.6.0", features = ["async"] }
 crossbeam = "0.8.1"
 libc.workspace = true
 log.workspace = true

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-protos"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",
@@ -33,7 +33,7 @@ name = "windows-log-reader"
 path = "examples/windows_log_reader.rs"
 
 [dependencies]
-containerd-shim-protos = { path = "../shim-protos", version = "0.5.0" }
+containerd-shim-protos = { path = "../shim-protos", version = "0.6.0" }
 go-flag = "0.1.0"
 lazy_static = "1.4.0"
 libc.workspace = true


### PR DESCRIPTION
This releases the containerd-shim and shim-protos packages which contain several dependencies updates, new features and bug fixes (not all inclusive):

- #206
- #212
- #211
- #213
- #194
- #201

