### PR TITLE
Bump to recent go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,10 @@ jobs:
       ## get latest go version for integrations tests so we can skip runnings tests
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.12'
 
       - name: Integration
         env:
-          GOPROXY: direct
           TEST_RUNTIME: "io.containerd.runc.v2-rs"
           TESTFLAGS_PARALLEL: 1
           EXTRA_TESTFLAGS: "-no-criu -test.skip='(TestContainerPTY|TestContainerExecLargeOutputWithTTY|TestTaskUpdate|TestTaskResize|TestContainerAttach|TestContainerAttachProcess)'"


### PR DESCRIPTION
CI is failing with 

```
go: github.com/Microsoft/hcsshim@v0.11.0 requires
	github.com/open-policy-agent/opa@v0.42.2 requires
	oras.land/oras-go@v1.2.0 requires
	github.com/distribution/distribution/v3@v3.0.0-20220526142353-ffbd94cbe269 requires
	github.com/mitchellh/osext@v0.0.0-20151018003038-5e2d6d41470f: invalid version: git ls-remote -q origin in /home/runner/go/pkg/mod/cache/vcs/94ed57c5b21c953d93b47487113db43a5c9b69fd990329ec70dc77348c4dd443: exit status [12](https://github.com/containerd/rust-extensions/actions/runs/7214723382/job/19657436957?pr=224#step:8:13)8:
	fatal: could not read Username for 'https://github.com/': terminal prompts disabled
```

I found a few issues that mention upgrading to recent versions of golang help.  I also think using the go proxy instead of direct might help as well as we've had issues related to that in the past