### PR TITLE
Return Container object in async `Runc::state()`

### DIFF
--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -560,7 +560,7 @@ impl Runc {
     }
 
     /// Return the state of a container
-    pub async fn state(&self, id: &str) -> Result<Vec<usize>> {
+    pub async fn state(&self, id: &str) -> Result<Container> {
         let args = vec!["state".to_string(), id.to_string()];
         let res = self.launch(self.command(&args)?, true).await?;
         serde_json::from_str(&res.output).map_err(Error::JsonDeserializationFailed)


### PR DESCRIPTION
It's a very small change so I figured it's simpler to open a PR than an issue first.

The sync `state` method returns `Container` but for async returns `Vec<usize>`, and I couldn't locate an explanation for why these might be different so I assume it's a mistake.  From a user perspective too I want Container rather than a usize vec.