### PR TITLE
The error will occur in containerdV1.7  syncexec function

### DIFF
--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -217,22 +217,19 @@ pub fn update_resources(pid: u32, resources: &LinuxResources) -> Result<()> {
             Subsystem::Mem(mem_ctr) => {
                 if let Some(memory) = resources.memory() {
                     //if swap and limit setting have
-                    match (memory.limit(), memory.swap()) {
-                        (Some(limit), Some(swap)) => {
-                            //get current memory_limit
-                            let current = mem_ctr.memory_stat().limit_in_bytes;
-                            // if the updated swap value is larger than the current memory limit set the swap changes first
-                            // then set the memory limit as swap must always be larger than the current limit
-                            if current < swap {
-                                mem_ctr
-                                    .set_memswap_limit(swap)
-                                    .map_err(other_error!(e, "set memsw limit"))?;
-                                mem_ctr
-                                    .set_limit(limit)
-                                    .map_err(other_error!(e, "set mem limit"))?;
-                            }
+                    if let (Some(limit), Some(swap)) = (memory.limit(), memory.swap()) {
+                        //get current memory_limit
+                        let current = mem_ctr.memory_stat().limit_in_bytes;
+                        // if the updated swap value is larger than the current memory limit set the swap changes first
+                        // then set the memory limit as swap must always be larger than the current limit
+                        if current < swap {
+                            mem_ctr
+                                .set_memswap_limit(swap)
+                                .map_err(other_error!(e, "set memsw limit"))?;
+                            mem_ctr
+                                .set_limit(limit)
+                                .map_err(other_error!(e, "set mem limit"))?;
                         }
-                        _ => (),
                     }
                     // set memory limit in bytes
                     if let Some(limit) = memory.limit() {

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -216,6 +216,24 @@ pub fn update_resources(pid: u32, resources: &LinuxResources) -> Result<()> {
             }
             Subsystem::Mem(mem_ctr) => {
                 if let Some(memory) = resources.memory() {
+                    //if swap and limit setting have 
+                    match (memory.limit(),memory.swap()){
+                        (Some(limit),Some(swap))=>{
+                            //get current memory_limit
+                            let current =  mem_ctr.memory_stat().limit_in_bytes;
+                            // if the updated swap value is larger than the current memory limit set the swap changes first
+		                    // then set the memory limit as swap must always be larger than the current limit
+                            if current < swap{
+                                mem_ctr
+                                .set_memswap_limit(swap)
+                                .map_err(other_error!(e, "set memsw limit"))?;
+                                mem_ctr
+                                .set_limit(limit)
+                                .map_err(other_error!(e, "set mem limit"))?;
+                            }
+                        }
+                        _=>(),
+                    }
                     // set memory limit in bytes
                     if let Some(limit) = memory.limit() {
                         mem_ctr

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -229,6 +229,7 @@ pub fn update_resources(pid: u32, resources: &LinuxResources) -> Result<()> {
                             mem_ctr
                                 .set_limit(limit)
                                 .map_err(other_error!(e, "set mem limit"))?;
+                            return Ok(());
                         }
                     }
                     // set memory limit in bytes

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -216,23 +216,23 @@ pub fn update_resources(pid: u32, resources: &LinuxResources) -> Result<()> {
             }
             Subsystem::Mem(mem_ctr) => {
                 if let Some(memory) = resources.memory() {
-                    //if swap and limit setting have 
-                    match (memory.limit(),memory.swap()){
-                        (Some(limit),Some(swap))=>{
+                    //if swap and limit setting have
+                    match (memory.limit(), memory.swap()) {
+                        (Some(limit), Some(swap)) => {
                             //get current memory_limit
-                            let current =  mem_ctr.memory_stat().limit_in_bytes;
+                            let current = mem_ctr.memory_stat().limit_in_bytes;
                             // if the updated swap value is larger than the current memory limit set the swap changes first
-		                    // then set the memory limit as swap must always be larger than the current limit
-                            if current < swap{
+                            // then set the memory limit as swap must always be larger than the current limit
+                            if current < swap {
                                 mem_ctr
-                                .set_memswap_limit(swap)
-                                .map_err(other_error!(e, "set memsw limit"))?;
+                                    .set_memswap_limit(swap)
+                                    .map_err(other_error!(e, "set memsw limit"))?;
                                 mem_ctr
-                                .set_limit(limit)
-                                .map_err(other_error!(e, "set mem limit"))?;
+                                    .set_limit(limit)
+                                    .map_err(other_error!(e, "set mem limit"))?;
                             }
                         }
-                        _=>(),
+                        _ => (),
                     }
                     // set memory limit in bytes
                     if let Some(limit) = memory.limit() {


### PR DESCRIPTION
you can get this error  easliy  when you run TestContainerDrainExecIOAfterExit function
ps: should kill this container when the process just leave a init process?