### PR TITLE
When the containerd process is restarted, a large number of sigpipe signals occur, leading to the containerd process freezing.

### DIFF
--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -307,6 +307,7 @@ async fn handle_signals(signals: Signals) {
     let mut signals = signals.fuse();
     while let Some(sig) = signals.next().await {
         match sig {
+            SIGPIPE => {}
             SIGTERM | SIGINT => {
                 debug!("received {}", sig);
             }


### PR DESCRIPTION
**Problem Description**
When there are running containers in the environment and the containerd process is restarted, the containerd process may hang, and the ctr command will also hang.
Note:
The containerd log is as follows:
[log-containerd.txt](https://github.com/containerd/rust-extensions/files/14092598/log-containerd.txt)


**Reason**
When the containerd process is restarted, containerd randomly reads the pipe of the container or pod located at /var/run/containerd/io.containerd.runtime.v2.task/k8s.io/. Since the read end of the shim's pipe is closed, reading from the shim's pipe causes a sigpipe signal. In debug mode, when this signal is received, a log is written, but since the read end is closed, it enters an infinite loop, causing the containerd process to hang.

**Solution**
When a sigpipe signal is received, there is no need to print a debug log. Simply return without further processing.
