### PR TITLE
Use RUST_LOG env to configure logging if present

### DIFF
--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -166,7 +166,12 @@ where
         }
         _ => {
             if !config.no_setup_logger {
-                logger::init(flags.debug, &flags.namespace, &flags.id)?;
+                logger::init(
+                    flags.debug,
+                    &config.default_log_level,
+                    &flags.namespace,
+                    &flags.id,
+                )?;
             }
 
             let publisher = RemotePublisher::new(&ttrpc_address).await?;

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -109,14 +109,27 @@ cfg_async! {
 const TTRPC_ADDRESS: &str = "TTRPC_ADDRESS";
 
 /// Config of shim binary options provided by shim implementations
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Config {
     /// Disables automatic configuration of logrus to use the shim FIFO
     pub no_setup_logger: bool,
+    // Sets the the default log level. Default is info
+    pub default_log_level: String,
     /// Disables the shim binary from reaping any child process implicitly
     pub no_reaper: bool,
     /// Disables setting the shim as a child subreaper.
     pub no_sub_reaper: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            no_setup_logger: false,
+            default_log_level: "info".to_string(),
+            no_reaper: false,
+            no_sub_reaper: false,
+        }
+    }
 }
 
 /// Startup options received from containerd to start new shim instance.

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -255,7 +255,12 @@ where
             util::setup_debugger_event();
 
             if !config.no_setup_logger {
-                logger::init(flags.debug, &flags.namespace, &flags.id)?;
+                logger::init(
+                    flags.debug,
+                    &config.default_log_level,
+                    &flags.namespace,
+                    &flags.id,
+                )?;
             }
 
             let publisher = publisher::RemotePublisher::new(&ttrpc_address)?;


### PR DESCRIPTION
We identified a perf impact when writing logs.  In this case it would be helpful to only run with logs set at a "warning" or "error" level.  We attempted to turn most logs off via containerd with `containerd -l fatal` but it still dumped logs.  

After some investigation it appears containerd only sets a flag not a level (https://github.com/containerd/containerd/blob/7467d81987e1a54dd2a89e052ae9429a4c921e9e/core/runtime/v2/binary.go#L66-L68) and our code will default to info https://github.com/containerd/rust-extensions/blob/cc445f54c0fa8e9b35376550874422c932ad1566/crates/shim/src/logger.rs#L135-L139

## changes
This reads the environment variable `RUST_LOG` and will use value from there if set. It can be set to any values in the [log crate](https://docs.rs/log/latest/log/enum.LevelFilter.html#variants). Otherwise the behavior is the same. If the `-debug` flag is passed it will choose the highest of the two values.

This also introduces ability to configure the default setting through the shim `Config` object:

```
run::<Shim>(&id, Some(Config{default_log_level: "error", ..Default::default()}));
```
If all the configuration fails it will fallback to logging to to `info` level.