### PR TITLE
Release 0.7.0 of Shim and 0.5.0 of client

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-client"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",

--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-containerd-shim = { path = "../shim", version = "0.6.0", features = ["async"] }
+containerd-shim = { path = "../shim", version = "0.7.0", features = ["async"] }
 crossbeam = "0.8.1"
 libc.workspace = true
 log.workspace = true

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-protos"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",
@@ -33,7 +33,7 @@ name = "windows-log-reader"
 path = "examples/windows_log_reader.rs"
 
 [dependencies]
-containerd-shim-protos = { path = "../shim-protos", version = "0.6.0" }
+containerd-shim-protos = { path = "../shim-protos", version = "0.7.0" }
 go-flag = "0.1.0"
 lazy_static = "1.4.0"
 libc.workspace = true


### PR DESCRIPTION
There have been some dependency version increases, updates to the protobuf files and small improvements since last release.  

In runwasi, we are blocked on an update since the containerd client wasn't on prost-types 12.x: https://github.com/containerd/runwasi/pull/488