### PR TITLE
fix(shim): rewrite cgroups v2 parsing logic

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -63,7 +63,7 @@ signal-hook-tokio = { version = "0.3.1", optional = true, features = [
 tokio = { workspace = true, features = ["full"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-cgroups-rs = "0.3.3"
+cgroups-rs = "0.3.4"
 
 [target.'cfg(unix)'.dependencies]
 command-fds = "0.3.0"

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -209,7 +209,7 @@ pub fn get_cgroups_v2_path_by_pid(pid: u32) -> Result<PathBuf> {
 // https://github.com/opencontainers/runc/blob/1950892f69597aa844cbf000fbdf77610dda3a44/libcontainer/cgroups/fs2/defaultpath.go#L83
 fn parse_cgroups_v2_path(content: &str) -> Result<PathBuf> {
     // the entry for cgroup v2 is always in the format like `0::$PATH`
-    // where 0 is the hierarchy ID, the controller name is ommit in cgroup v2
+    // where 0 is the hierarchy ID, the controller name is omitted in cgroup v2
     // and $PATH is the cgroup path
     // see https://docs.kernel.org/admin-guide/cgroup-v2.html
     let Some(path) = content.strip_prefix("0::") else {

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -194,7 +194,7 @@ pub fn get_cgroups_v2_path_by_pid(pid: u32) -> Result<String> {
     // todo: should upstream to cgroups-rs
     let path = format!("/proc/{}/cgroup", pid);
     let content = fs::read_to_string(path).map_err(io_error!(e, "read cgroup"))?;
-    let content = content.trim_end_matches('\n');
+    let content = content.lines().next().unwrap_or("");
 
     parse_cgroups_v2_path(content)
 }

--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -201,7 +201,7 @@ pub fn get_cgroups_v2_path_by_pid(pid: u32) -> Result<PathBuf> {
     let content = content.lines().next().unwrap_or("");
 
     let Ok(path) = parse_cgroups_v2_path(content)?.canonicalize() else {
-        return Err(Error::Other(format!("cgroup path not found")));
+        return Err(Error::Other("cgroup path not found".to_string()));
     };
     Ok(path)
 }


### PR DESCRIPTION
this commit rewrites the cgroups v2 parsing logic in get_cgroup function which is used to fetch stats of a container. The reason for the rewrite was that in some cases the original logic would panic due to index of bound for parsing paths like

`0::/kubepods-besteffort-pod162385e5_7f69_4c38_ba9c_db0a8f02b35e.slice:cri-containerd:278a0aac1fff30dfbc41b4a32ba9de4519928fe7480213dba87aa1498838ef34`

we ran into this issue in deleting a spin container in the spin shim.

the rewrite replaces index access to properly propogate the error to the caller of the function and added a few unit tests for the parsing logic.

see more discussion https://github.com/spinkube/containerd-shim-spin/issues/39, https://github.com/containerd/runwasi/issues/418
