### PR TITLE
Release fix for cgroup parsing

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-containerd-shim = { path = "../shim", version = "0.7.0", features = ["async"] }
+containerd-shim = { path = "../shim", version = "0.7.1", features = ["async"] }
 crossbeam = "0.8.1"
 libc.workspace = true
 log.workspace = true

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
   "Maksym Pavlenko <pavlenko.maksym@gmail.com>",
   "The containerd Authors",


### PR DESCRIPTION
Patch release for #254 which is causing issues in https://github.com/containerd/runwasi/issues/418