### PR TITLE
Enable type names for Protocol Buffer message types to support `Any` decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ oci-spec = "0.6"
 os_pipe = "1.1"
 prctl = "1.0.0"
 prost = "0.12"
+prost-build = "0.12"
 prost-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -31,6 +31,7 @@ tower = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-build.workspace = true
+prost-build.workspace = true
 
 [features]
 connect = ["tokio", "tower"]

--- a/crates/client/build.rs
+++ b/crates/client/build.rs
@@ -65,9 +65,12 @@ const FIXUP_MODULES: &[&str] = &[
 ];
 
 fn main() {
+    let mut config = prost_build::Config::new();
+    config.enable_type_names();
+
     tonic_build::configure()
         .build_server(false)
-        .compile(PROTO_FILES, &["vendor/"])
+        .compile_with_config(config, PROTO_FILES, &["vendor/"])
         .expect("Failed to generate GRPC bindings");
 
     for module in FIXUP_MODULES {

--- a/crates/client/examples/container_events.rs
+++ b/crates/client/examples/container_events.rs
@@ -47,7 +47,7 @@ async fn main() {
                                 // required by the `Any` type specification. We add it manually here so that `prost` can
                                 // properly decode the payload.
                                 if !payload.type_url.starts_with('/') {
-                                    payload.type_url.insert_str(0, "/");
+                                    payload.type_url.insert(0, '/');
                                 }
 
                                 let payload: ContainerCreate = payload
@@ -66,7 +66,7 @@ async fn main() {
                                 // required by the `Any` type specification. We add it manually here so that `prost` can
                                 // properly decode the payload.
                                 if !payload.type_url.starts_with('/') {
-                                    payload.type_url.insert_str(0, "/");
+                                    payload.type_url.insert(0, '/');
                                 }
 
                                 let payload: ContainerDelete = payload

--- a/crates/client/examples/container_events.rs
+++ b/crates/client/examples/container_events.rs
@@ -42,24 +42,41 @@ async fn main() {
                 if let Some(event) = event {
                     match event.topic.as_str() {
                         "/containers/create" => {
-                            if let Some(payload) = event.event {
+                            if let Some(mut payload) = event.event {
+                                // Containerd doesn't send event payloads with a leading slash on the type URL, which is
+                                // required by the `Any` type specification. We add it manually here so that `prost` can
+                                // properly decode the payload.
+                                if !payload.type_url.starts_with('/') {
+                                    payload.type_url.insert_str(0, "/");
+                                }
+
                                 let payload: ContainerCreate = payload
                                     .to_msg()
                                     .expect("failed to parse ContainerCreate payload");
 
                                 println!(
-                                    "container created: id={} image={}",
-                                    payload.id, payload.image
+                                    "container created: id={} payload={:?}",
+                                    payload.id, payload
                                 );
                             }
                         }
                         "/containers/delete" => {
-                            if let Some(payload) = event.event {
+                            if let Some(mut payload) = event.event {
+                                // Containerd doesn't send event payloads with a leading slash on the type URL, which is
+                                // required by the `Any` type specification. We add it manually here so that `prost` can
+                                // properly decode the payload.
+                                if !payload.type_url.starts_with('/') {
+                                    payload.type_url.insert_str(0, "/");
+                                }
+
                                 let payload: ContainerDelete = payload
                                     .to_msg()
                                     .expect("failed to parse ContainerDelete payload");
 
-                                println!("container deleted: id={}", payload.id);
+                                println!(
+                                    "container deleted: id={} payload={:?}",
+                                    payload.id, payload
+                                );
                             }
                         }
                         _ => {}

--- a/crates/client/examples/container_events.rs
+++ b/crates/client/examples/container_events.rs
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use client::{
+    events::{ContainerCreate, ContainerDelete},
+    services::v1::{events_client::EventsClient, SubscribeRequest},
+};
+use containerd_client as client;
+
+/// Make sure you run containerd before running this example.
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let channel = client::connect("/run/containerd/containerd.sock")
+        .await
+        .expect("Connect Failed");
+
+    let mut client = EventsClient::new(channel.clone());
+
+    let request = SubscribeRequest::default();
+    let mut response = client
+        .subscribe(request)
+        .await
+        .expect("failed to subscribe to events")
+        .into_inner();
+
+    loop {
+        match response.message().await {
+            Ok(event) => {
+                if let Some(event) = event {
+                    match event.topic.as_str() {
+                        "/containers/create" => {
+                            if let Some(payload) = event.event {
+                                let payload: ContainerCreate = payload
+                                    .to_msg()
+                                    .expect("failed to parse ContainerCreate payload");
+
+                                println!(
+                                    "container created: id={} image={}",
+                                    payload.id, payload.image
+                                );
+                            }
+                        }
+                        "/containers/delete" => {
+                            if let Some(payload) = event.event {
+                                let payload: ContainerDelete = payload
+                                    .to_msg()
+                                    .expect("failed to parse ContainerDelete payload");
+
+                                println!("container deleted: id={}", payload.id);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("error while streaming events: {:?}", e);
+                break;
+            }
+        }
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -248,8 +248,9 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::events::ContainerCreate;
     use prost_types::Any;
+
+    use crate::events::ContainerCreate;
 
     #[test]
     fn any_roundtrip() {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -245,3 +245,23 @@ impl Client {
         ContainersClient::new(self.channel())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::events::ContainerCreate;
+    use prost_types::Any;
+
+    #[test]
+    fn any_roundtrip() {
+        let original = ContainerCreate {
+            id: "test".to_string(),
+            image: "test".to_string(),
+            runtime: None,
+        };
+
+        let any = Any::from_msg(&original).expect("should not fail to encode");
+        let decoded: ContainerCreate = any.to_msg().expect("should not fail to decode");
+
+        assert_eq!(original, decoded)
+    }
+}


### PR DESCRIPTION
## Context

When using something like [`EventsClient::subscribe`](https://docs.rs/containerd-client/0.5.0/containerd_client/services/v1/events_client/struct.EventsClient.html#method.subscribe), the [`Envelope`](https://docs.rs/containerd-client/0.5.0/containerd_client/services/v1/struct.Envelope.html) value returned provides the event data (if any) behind [`prost_types::Any`](https://docs.rs/prost-types/latest/prost_types/struct.Any.html).

This value can be fallibly decoded to the underlying type (such as [`containerd_client::events::ContainerCreate`](https://docs.rs/containerd-client/0.5.0/containerd_client/events/struct.ContainerCreate.html) for a container create event) by using [`Any::to_msg<M>`](https://docs.rs/prost-types/latest/prost_types/struct.Any.html#method.to_msg), but _only_ if `M` implements [`Name`](https://docs.rs/prost/0.12.4/prost/trait.Name.html).

Currently, based on how `tonic_build` is used to do the codegen, the `Name` trait is not implemented for any of the generated message types, making decoding much harder to do.

## Solution

This PR is a simple change that simply provides _additional_ configuration in `build.rs`, enabling the generation of `Name` implementations for message types. [`Builder::compile_with_config`](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html) simply re-applies any of its own configuration on top of the configuration value given, so we're essentially just starting with a base of "enable type `Name` generation" and whatever else comes after (via `tonic_build::configure()...`) gets applied on top.