### PR TITLE
return pid=0 to connect interface when get an error.

### DIFF
--- a/crates/runc-shim/src/task.rs
+++ b/crates/runc-shim/src/task.rs
@@ -399,11 +399,14 @@ where
         req: ConnectRequest,
     ) -> TtrpcResult<ConnectResponse> {
         info!("Connect request for {:?}", req);
-        let container = self.get_container(req.id()).await?;
+        let mut pid: u32 = 0;
+        if let Ok(container) = self.get_container(req.id()).await {
+            pid = container.pid().await as u32;
+        }
 
         Ok(ConnectResponse {
             shim_pid: std::process::id(),
-            task_pid: container.pid().await as u32,
+            task_pid: pid,
             ..Default::default()
         })
     }


### PR DESCRIPTION
When get_container return an error, just return pid=0 to connect interface.