### PR TITLE
set shim worker thread num 

### DIFF
--- a/crates/runc-shim/src/runc.rs
+++ b/crates/runc-shim/src/runc.rs
@@ -460,6 +460,7 @@ impl ProcessLifecycle<ExecProcess> for RuncExecLifecycle {
             return Err(Error::Other("cannot delete a running process".to_string()));
         }
         self.exit_signal.signal();
+        self.exit_signal.wait_for_exit(tokio::time::Duration::from_secs(2)).await;
         let exec_pid_path = Path::new(self.bundle.as_str()).join(format!("{}.pid", p.id));
         remove_file(exec_pid_path).await.unwrap_or_default();
         Ok(())

--- a/crates/runc-shim/src/runc.rs
+++ b/crates/runc-shim/src/runc.rs
@@ -456,6 +456,9 @@ impl ProcessLifecycle<ExecProcess> for RuncExecLifecycle {
     }
 
     async fn delete(&self, p: &mut ExecProcess) -> Result<()> {
+        if p.state == Status::RUNNING {
+            return Err(Error::Other("cannot delete a running process".to_string()));
+        }
         self.exit_signal.signal();
         let exec_pid_path = Path::new(self.bundle.as_str()).join(format!("{}.pid", p.id));
         remove_file(exec_pid_path).await.unwrap_or_default();

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -125,6 +125,9 @@ where
 
     // Setup signals
     let signals = setup_signals_tokio(&config);
+    tokio::spawn(async move {
+        handle_signals(signals).await;
+    });
 
     if !config.no_sub_reaper {
         reap::set_subreaper()?;
@@ -154,9 +157,6 @@ where
             Ok(())
         }
         "delete" => {
-            tokio::spawn(async move {
-                handle_signals(signals).await;
-            });
             let response = shim.delete_shim().await?;
             let resp_bytes = response.write_to_bytes()?;
             tokio::io::stdout()
@@ -185,9 +185,6 @@ where
             server.start().await?;
 
             info!("Shim successfully started, waiting for exit signal...");
-            tokio::spawn(async move {
-                handle_signals(signals).await;
-            });
             shim.wait().await;
 
             info!("Shutting down shim instance");


### PR DESCRIPTION
The current shim process can run on all cores in the system, which is not suitable for scenarios with high CPU load. In runtime, the number of shim worker threads can be controlled through environment variables RUSTMAXPROCS.