### PR TITLE
chore: Update `nix` package to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/shim-protos",
   "crates/snapshots",
 ]
+resolver = "2"
 
 [profile.release]
 # Keep binary as small as possible
@@ -30,7 +31,7 @@ crossbeam = "0.8.1"
 futures = "0.3.19"
 libc = "0.2.112"
 log = {version = "0.4.2", features=["kv_unstable"]}
-nix = "0.28"
+nix = "0.29"
 oci-spec = "0.6"
 os_pipe = "1.1"
 prctl = "1.0.0"

--- a/crates/runc-shim/src/common.rs
+++ b/crates/runc-shim/src/common.rs
@@ -194,8 +194,8 @@ pub fn receive_socket(stream_fd: RawFd) -> containerd_shim::Result<OwnedFd> {
     let (path, fds) =
         match recvmsg::<UnixAddr>(stream_fd, &mut iovec, Some(&mut space), MsgFlags::empty()) {
             Ok(msg) => {
-                let mut iter = msg.cmsgs();
-                if let Some(ControlMessageOwned::ScmRights(fds)) = iter.next() {
+                let iter = msg.cmsgs();
+                if let Some(ControlMessageOwned::ScmRights(fds)) = iter?.next() {
                     (iovec[0].deref(), fds)
                 } else {
                     return Err(other!("received message is empty"));


### PR DESCRIPTION
Added `resolver = 2` to Cargo.toml per suggestion

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/60dcae30-0a18-4f9b-8449-5c5595f5810c">

Closes #272