### PR TITLE
Process not found should not return ok

### DIFF
--- a/crates/runc-shim/src/container.rs
+++ b/crates/runc-shim/src/container.rs
@@ -136,7 +136,6 @@ where
         let process = self.get_mut_process(exec_id_opt);
         match process {
             Ok(p) => p.delete().await?,
-            Err(Error::NotFoundError(_)) => return Ok((pid, code, exited_at)),
             Err(e) => return Err(e),
         }
         if let Some(exec_id) = exec_id_opt {
@@ -228,7 +227,7 @@ where
         match exec_id {
             Some(exec_id) => {
                 let p = self.processes.get_mut(exec_id).ok_or_else(|| {
-                    Error::NotFoundError("can not find the exec by id".to_string())
+                    Error::NotFoundError(format!("can not find the exec by id {}", exec_id))
                 })?;
                 Ok(p)
             }


### PR DESCRIPTION
 if the process ID is not found, I think an error should be returned.