### PR TITLE
Fix compatibility with latest ttrpc and pin ttrpc version to 0.8.2

### DIFF
--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -50,10 +50,10 @@ required-features = ["async"]
 [dependencies]
 async-trait = { workspace = true, optional = true }
 protobuf = "=3.5"
-ttrpc = "0.8"
+ttrpc = "0.8.2"
 
 [build-dependencies]
-ttrpc-codegen = "0.4"
+ttrpc-codegen = "0.4.2"
 
 [dev-dependencies]
 ctrlc = { version = "3.0", features = ["termination"] }

--- a/crates/shim-protos/examples/ttrpc-server-async.rs
+++ b/crates/shim-protos/examples/ttrpc-server-async.rs
@@ -60,9 +60,7 @@ impl Task for FakeServer {
 async fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let t = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
-    let t = Arc::new(t);
-    let tservice = create_task(t);
+    let tservice = create_task(Arc::new(FakeServer::new()));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/examples/ttrpc-server.rs
+++ b/crates/shim-protos/examples/ttrpc-server.rs
@@ -57,9 +57,7 @@ impl Task for FakeServer {
 fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let t = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
-    let t = Arc::new(t);
-    let tservice = create_task(t);
+    let tservice = create_task(Arc::new(FakeServer::new()));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/tests/ttrpc.rs
+++ b/crates/shim-protos/tests/ttrpc.rs
@@ -72,9 +72,7 @@ fn create_ttrpc_context() -> (
 
 #[test]
 fn test_task_method_num() {
-    let server = Arc::new(Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>);
-    let task = create_task(server.clone());
-
+    let task = create_task(Arc::new(FakeServer::new()));
     assert_eq!(task.len(), 17);
 }
 
@@ -98,8 +96,7 @@ fn test_create_task() {
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
 
-    let server = Arc::new(Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>);
-    let task = create_task(server.clone());
+    let task = create_task(Arc::new(FakeServer::new()));
     let create = task.get("/containerd.task.v2.Task/Create").unwrap();
     create.handler(ctx, request).unwrap();
 
@@ -140,8 +137,7 @@ fn test_delete_task() {
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
 
-    let server = Arc::new(Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>);
-    let task = create_task(server.clone());
+    let task = create_task(Arc::new(FakeServer::new()));
     let delete = task.get("/containerd.task.v2.Task/Delete").unwrap();
     delete.handler(ctx, request).unwrap();
 

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -178,7 +178,7 @@ where
 
             let publisher = RemotePublisher::new(&ttrpc_address).await?;
             let task = shim.create_task_service(publisher).await;
-            let task_service = create_task(Arc::new(Box::new(task)));
+            let task_service = create_task(Arc::new(task));
             let mut server = Server::new().register_service(task_service);
             server = server.add_listener(SOCKET_FD)?;
             server = server.set_domain_unix();

--- a/crates/shim/src/asynchronous/publisher.rs
+++ b/crates/shim/src/asynchronous/publisher.rs
@@ -148,8 +148,7 @@ mod tests {
         let barrier2 = barrier.clone();
         let server_thread = tokio::spawn(async move {
             let listener = UnixListener::bind(&path1).unwrap();
-            let t = Arc::new(Box::new(server) as Box<dyn Events + Send + Sync>);
-            let service = create_events(t);
+            let service = create_events(Arc::new(server));
             let mut server = Server::new()
                 .set_domain_unix()
                 .add_listener(listener.as_raw_fd())

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -266,7 +266,7 @@ where
 
             let publisher = publisher::RemotePublisher::new(&ttrpc_address)?;
             let task = shim.create_task_service(publisher);
-            let task_service = create_task(Arc::new(Box::new(task)));
+            let task_service = create_task(Arc::new(task));
             let mut server = create_server(flags)?;
             server = server.register_service(task_service);
             server.start()?;

--- a/crates/shim/src/synchronous/publisher.rs
+++ b/crates/shim/src/synchronous/publisher.rs
@@ -188,8 +188,7 @@ mod tests {
             use std::os::unix::{io::AsRawFd, net::UnixListener};
             let listener = UnixListener::bind(server_address).unwrap();
             listener.set_nonblocking(true).unwrap();
-            let t = Arc::new(Box::new(FakeServer {}) as Box<dyn Events + Send + Sync>);
-            let service = client::create_events(t);
+            let service = client::create_events(Arc::new(FakeServer {}));
             let server = Server::new()
                 .add_listener(listener.as_raw_fd())
                 .unwrap()
@@ -200,8 +199,7 @@ mod tests {
 
         #[cfg(windows)]
         {
-            let t = Arc::new(Box::new(FakeServer {}) as Box<dyn Events + Send + Sync>);
-            let service = client::create_events(t);
+            let service = client::create_events(Arc::new(FakeServer {}));
 
             Server::new()
                 .bind(server_address)


### PR DESCRIPTION
Looks like new version of ttrpc introduces some backward incompatible changes (https://github.com/containerd/ttrpc-rust/pull/235), this PR makes a few fixes in `shim` and `shim-protos` crates.

cc: @Mossaka 

ref: https://github.com/containerd/rust-extensions/pull/317

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>
