### PR TITLE
fix leftover shim processes

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -44,3 +44,4 @@ tokio = { workspace = true, features = ["full"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs.workspace = true
 nix = { workspace = true, features = ["event"] }
+tokio-eventfd = "0.2.1"


### PR DESCRIPTION
The tokio::fs module should only be used for ordinary files. Trying to use it with e.g., a named pipe on Linux can result in surprising behavior, such as hangs during runtime shutdown. 
https://docs.rs/tokio/1.41.1/tokio/fs/index.html

shim often hang at eventfd_file.read
ps -auxf
```
root      360540  0.1  0.0  23988  4876 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 5e2ad5d0842fc923f006c
root      360840  0.1  0.0  19868  4984 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id a95c3fc46f9c0eaf3eb02
root      360861  0.1  0.0  19860  4744 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 8143801c7022ac9b9c372
root      360913  0.1  0.0  19872  4900 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 87a06c6eb2f955ced98af
root      364730  0.1  0.0  21924  4956 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 95b5ea679f891e0b514c4
root      364817  0.1  0.0  23992  4972 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 8a3861b051c4062f8acae
root      365193  0.1  0.0  19868  5012 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 51e671a1ebbb29e76784f
root      365273  0.1  0.0  19860  4812 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 0b47798a8536650301254
root      365292  0.1  0.0  21928  4852 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id e74733b397703d52a7184
root      365454  0.1  0.0  21928  4948 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id bde5e5f5b27ac6c8fced2
root      365623  0.1  0.0  19864  4964 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 5dee55159c92e9c28e8df
root      365728  0.1  0.0  19864  4980 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id a798f80ec940cba4e1c37
root      365804  0.1  0.0  19872  4808 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 012e1cbbf7f0a4a78dd9a
root      365850  0.1  0.0  19864  4892 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 50e5676694ae2209a8cda
root      365859  0.1  0.0  19860  4824 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id d4794a3cfadd98f25f3a5
root      365876  0.1  0.0  21924  4688 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id c902691dd08614d828209
root      365933  0.1  0.0  19864  4992 ?        Sl   21:03   0:00 /usr/bin/containerd-shim-runc-v2-rs -namespace k8s.io -id 0e7fc9316279acd545355

[root@host-10-234-75-223 bucketbench]# crictl ps
CONTAINER           IMAGE               CREATED             STATE               NAME                ATTEMPT             POD ID              POD
[root@host-10-234-75-223 bucketbench]# crictl pods
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME
[root@host-10-234-75-223 bucketbench]# 

```
refer https://github.com/containers/conmon-rs/blob/ad7ada97446ac82200d98280228cab76386fa699/conmon-rs/server/src/oom_watcher.rs#L132
@mxpv 