### PR TITLE
Attempt to change mutex to rwlock

### DIFF
--- a/crates/runc-shim/src/service.rs
+++ b/crates/runc-shim/src/service.rs
@@ -159,7 +159,7 @@ async fn process_exits(
             if let Subject::Pid(pid) = e.subject {
                 debug!("receive exit event: {}", &e);
                 let exit_code = e.exit_code;
-                for (_k, cont) in containers.lock().await.iter_mut() {
+                for (_k, cont) in containers.write().await.iter_mut() {
                     let bundle = cont.bundle.to_string();
                     // pid belongs to container init process
                     if cont.init.pid == pid {


### PR DESCRIPTION
In high concurrency environments, some operations are read-only and do not require mutex write locks.So in tasks that only require reading locks, there will be no mutual blocking.