### PR TITLE
Upgrade the rustc version. Because build fail.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77"
+channel = "1.81"
 components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
because this error
"package `home v0.5.11` cannot be built \
because it requires rustc 1.81 or newer,\
while the currently active rustc version is 1.77.2"