### PR TITLE
Update containerd versions for Linux integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        containerd: [v1.6.28, v1.7.13, v2.0.0-beta.2]
+        containerd: [v1.6.36, v1.7.24, v2.0.1]
 
     steps:
       - name: Checkout extensions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       ## get latest go version for integrations tests so we can skip runnings tests
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.12'
+          go-version: '1.23'
 
       - name: Integration
         env:


### PR DESCRIPTION
Updates containerd versions: containerd 2.0 is now out, and there are a few bug fix releases in 1.6/1.7