### PR TITLE
Add a to_any helper in the containerd client crate

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -119,6 +119,19 @@ pub async fn connect(
     Ok(channel)
 }
 
+use prost::{Message, Name};
+use prost_types::Any;
+
+// to_any provides a helper to match the current use of the protobuf "fullname" trait
+// in the Go code on the gRPC server side in containerd when handling matching of Any
+// types to registered types on the server. Further discussion on future direction
+// of typeurl in this issue: https://github.com/containerd/rust-extensions/issues/362
+pub fn to_any<T: Message + Name>(m: &T) -> Any {
+    let mut anyt = Any::from_msg(m).unwrap();
+    anyt.type_url = T::full_name();
+    anyt
+}
+
 /// Help to inject namespace into request.
 ///
 /// To use this macro, the `tonic::Request` is needed.


### PR DESCRIPTION
Fixes: #362 

This provides a solution to Any->type matching that happens on the containerd Go-based server side where the Any types in prost use typeurl as defined in the protobuf spec and the server side is matching on the fullname property of the type.