### PR TITLE
Fix complie error

### DIFF
--- a/crates/client/vendor/github.com/containerd/containerd/api/services/images/v1/images.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/services/images/v1/images.proto
@@ -145,5 +145,5 @@ message DeleteImageRequest {
 	//
 	// If image descriptor does not match the same digest,
 	// the delete operation will return "not found" error.
-	optional containerd.types.Descriptor target = 3;
+	containerd.types.Descriptor target = 3;
 }

--- a/crates/client/vendor/github.com/containerd/containerd/api/types/fieldpath.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/types/fieldpath.proto
@@ -34,9 +34,9 @@ import "google/protobuf/descriptor.proto";
 option go_package = "github.com/containerd/containerd/api/types;types";
 
 extend google.protobuf.FileOptions {
-	optional bool fieldpath_all = 63300;
+	bool fieldpath_all = 63300;
 }
 
 extend google.protobuf.MessageOptions {
-	optional bool fieldpath = 64400;
+	bool fieldpath = 64400;
 }

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -52,7 +52,7 @@ async-trait = { workspace = true, optional = true }
 # protobuf 3.5 introduces a breaking change: https://github.com/containerd/rust-extensions/issues/295
 # pinning to <3.5.0 until we can update the generated code
 protobuf = ">= 3.0, <3.5.0"
-ttrpc = "0.8.2"
+ttrpc = "0.8.3"
 
 [build-dependencies]
 ttrpc-codegen = "0.4.2"

--- a/crates/shim/src/asynchronous/mod.rs
+++ b/crates/shim/src/asynchronous/mod.rs
@@ -177,8 +177,9 @@ where
             }
 
             let publisher = RemotePublisher::new(&ttrpc_address).await?;
-            let task = shim.create_task_service(publisher).await;
-            let task_service = create_task(Arc::new(Box::new(task)));
+            let task = Box::new(shim.create_task_service(publisher).await)
+                as Box<dyn containerd_shim_protos::shim_async::Task + Send + Sync>;
+            let task_service = create_task(Arc::from(task));
             let mut server = Server::new().register_service(task_service);
             server = server.add_listener(SOCKET_FD)?;
             server = server.set_domain_unix();

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -265,8 +265,9 @@ where
             }
 
             let publisher = publisher::RemotePublisher::new(&ttrpc_address)?;
-            let task = shim.create_task_service(publisher);
-            let task_service = create_task(Arc::new(Box::new(task)));
+            let task = Box::new(shim.create_task_service(publisher))
+                as Box<dyn containerd_shim_protos::Task + Send + Sync + 'static>;
+            let task_service = create_task(Arc::from(task));
             let mut server = create_server(flags)?;
             server = server.register_service(task_service);
             server.start()?;

--- a/crates/shim/src/synchronous/publisher.rs
+++ b/crates/shim/src/synchronous/publisher.rs
@@ -188,7 +188,8 @@ mod tests {
             use std::os::unix::{io::AsRawFd, net::UnixListener};
             let listener = UnixListener::bind(server_address).unwrap();
             listener.set_nonblocking(true).unwrap();
-            let service = client::create_events(Arc::new(Box::new(FakeServer {})));
+            let task = Box::new(FakeServer {}) as Box<dyn Events + Send + Sync>;
+            let service = client::create_events(task.into());
             let server = Server::new()
                 .add_listener(listener.as_raw_fd())
                 .unwrap()


### PR DESCRIPTION
1. update ttrpc version
2. proto3 syntax  "To define 'optional' fields in Proto3, simply remove the 'optional' label, as fields are 'optional' by default" 
3. compile fail because "required for the cast from `Arc<std::boxed::Box<<T as asynchronous::Shim>::T>>` to `Arc<(dyn containerd_shim_protos::shim_async::Task + std::marker::Send + Sync + 'static)>`"