### PR TITLE
add proto3 flag to fix cargo doc generation

### DIFF
--- a/crates/client/build.rs
+++ b/crates/client/build.rs
@@ -67,6 +67,7 @@ const FIXUP_MODULES: &[&str] = &[
 
 fn main() {
     let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
     config.enable_type_names();
 
     tonic_build::configure()


### PR DESCRIPTION
I noticed cargo docs are failing for this crate because the protoc version in the build environment doesn't by default support optional for proto3. Adding the `--experimental_allow_proto3_optional` flag should fix this.