### PR TITLE
Change CI's rustup version to use rust-toolchain.toml 's version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      # Use the rust-toolchain-file 
+      - uses: dsherret/rust-toolchain-file@v1
       - run: ./scripts/install-protobuf.sh
         shell: bash
 
-      - run: rustup toolchain install nightly --component rustfmt
-      - run: cargo +nightly fmt --all -- --check
+      - run: cargo fmt --all -- --check
 
       # the "runc" and "containerd-shim" crates have `sync` code that is not covered by the workspace
       - run: cargo check -p runc --all-targets

--- a/crates/shim-protos/examples/ttrpc-server-async.rs
+++ b/crates/shim-protos/examples/ttrpc-server-async.rs
@@ -60,7 +60,8 @@ impl Task for FakeServer {
 async fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let tservice = create_task(Arc::new(Box::new(FakeServer::new())));
+    let fakeserver = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
+    let tservice = create_task(Arc::from(fakeserver));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/examples/ttrpc-server.rs
+++ b/crates/shim-protos/examples/ttrpc-server.rs
@@ -57,7 +57,8 @@ impl Task for FakeServer {
 fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let tservice = create_task(Arc::new(Box::new(FakeServer::new())));
+    let fakeserver = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
+    let tservice = create_task(Arc::from(fakeserver));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/tests/ttrpc.rs
+++ b/crates/shim-protos/tests/ttrpc.rs
@@ -72,7 +72,8 @@ fn create_ttrpc_context() -> (
 
 #[test]
 fn test_task_method_num() {
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let fakeserver = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
+    let task = create_task(Arc::from(fakeserver));
     assert_eq!(task.len(), 17);
 }
 
@@ -96,7 +97,8 @@ fn test_create_task() {
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
 
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let fakeserver = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
+    let task = create_task(Arc::from(fakeserver));
     let create = task.get("/containerd.task.v2.Task/Create").unwrap();
     create.handler(ctx, request).unwrap();
 
@@ -136,8 +138,8 @@ fn test_delete_task() {
     request.set_payload(buf);
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
-
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let fakeserver = Box::new(FakeServer::new()) as Box<dyn Task + Send + Sync>;
+    let task = create_task(Arc::from(fakeserver));
     let delete = task.get("/containerd.task.v2.Task/Delete").unwrap();
     delete.handler(ctx, request).unwrap();
 

--- a/crates/shim/src/asynchronous/publisher.rs
+++ b/crates/shim/src/asynchronous/publisher.rs
@@ -218,7 +218,8 @@ mod tests {
         let barrier2 = barrier.clone();
         let server_thread = tokio::spawn(async move {
             let listener = UnixListener::bind(&path1).unwrap();
-            let service = create_events(Arc::new(Box::new(server)));
+            let sserver = Box::new(server) as Box<dyn Events + Sync + Send>;
+            let service = create_events(Arc::from(sserver));
             let mut server = Server::new()
                 .set_domain_unix()
                 .add_listener(listener.as_raw_fd())


### PR DESCRIPTION
and fix test's fail. Ensure that the CI is consistent with the actual version of the rustup toolchain built.