### PR TITLE
feat(shim): make logger module public

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -56,7 +56,7 @@ pub use args::{parse, Flags};
 pub mod asynchronous;
 pub mod cgroup;
 pub mod event;
-mod logger;
+pub mod logger;
 pub mod monitor;
 pub mod mount;
 mod reap;


### PR DESCRIPTION
Downstream shim implementations can use this module to setup logger by themselves. One example is runwasi's container process needs to use this module to setup logger so that logs from the container process can be populated to containerd.