### PR TITLE
make the async feature a no-op on non-unix platforms

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -77,7 +77,7 @@ pub mod api {
 macro_rules! cfg_not_async {
     ($($item:item)*) => {
         $(
-            #[cfg(not(feature = "async"))]
+            #[cfg(not(all(feature = "async", target_family="unix")))]
             #[cfg_attr(docsrs, doc(cfg(not(feature = "async"))))]
             $item
         )*
@@ -87,7 +87,7 @@ macro_rules! cfg_not_async {
 macro_rules! cfg_async {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "async")]
+            #[cfg(all(feature = "async", target_family="unix"))]
             #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
             $item
         )*


### PR DESCRIPTION
Fixes #379