### PR TITLE
all(breaking): Fix typoes and add spell checking workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,11 @@ jobs:
     steps:
       - run: exit 1
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
+  spelling:
+    name: spell check with typos
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Spell Check Repo
+      uses: crate-ci/typos@master

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,15 @@
+[default]
+# allow disabling the next line, e.g:
+#         self.namespaces
+#             // typos:disable-next-line - false positive "typ"
+#             .retain(|ns| ns.typ() != LinuxNamespaceType::Network);
+extend-ignore-re = [
+   "(?Rm)^\\s*//\\s*typos:disable-next-line(\\s.*|\\s*)(\\r|\\n)+[^\\r\\n]*$",
+   # Match 'typ()' when used as a method call
+   "\\w+\\.typ\\(\\)",
+]
+
+[type.proto]
+extend-glob = ["*.proto"]
+check-file = false
+

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,10 +1,5 @@
 [default]
-# allow disabling the next line, e.g:
-#         self.namespaces
-#             // typos:disable-next-line - false positive "typ"
-#             .retain(|ns| ns.typ() != LinuxNamespaceType::Network);
 extend-ignore-re = [
-   "(?Rm)^\\s*//\\s*typos:disable-next-line(\\s.*|\\s*)(\\r|\\n)+[^\\r\\n]*$",
    # Match 'typ()' when used as a method call
    "\\w+\\.typ\\(\\)",
 ]

--- a/crates/runc-shim/README.md
+++ b/crates/runc-shim/README.md
@@ -34,7 +34,7 @@ Three different kinds of shim binaries are used to compare memory overhead, firs
 compiled by golang, next is our sync `containerd-shim-runc-v2-rs` and the last one is our async `containerd-shim-runc-v2-rs`
 but limited to 2 work threads.
 
-We run a *busybox* container inside a pod on a *16U32G Ubuntu20.04* mechine with *containerd v1.6.8* and *runc v1.1.4*.
+We run a *busybox* container inside a pod on a *16U32G Ubuntu20.04* machine with *containerd v1.6.8* and *runc v1.1.4*.
 To measure the memory size of shim process we parse the output of *smaps* file and add up all RSS segments.
 In addition, we also run 100 pods and collect the total memory overhead.
 

--- a/crates/runc-shim/src/runc.rs
+++ b/crates/runc-shim/src/runc.rs
@@ -807,16 +807,16 @@ mod tests {
             .await
             .expect("write log json should not be error");
 
-        let expectd_msg = "panic";
+        let expected_msg = "panic";
         let actual_err = runtime_error(test_dir, empty_err, "").await;
         remove_dir_all(test_dir)
             .await
             .expect("remove test dir should not be error");
         assert!(
-            actual_err.to_string().contains(expectd_msg),
+            actual_err.to_string().contains(expected_msg),
             "actual error \"{}\" should contains \"{}\"",
             actual_err,
-            expectd_msg
+            expected_msg
         );
     }
 }

--- a/crates/runc-shim/src/service.rs
+++ b/crates/runc-shim/src/service.rs
@@ -226,7 +226,7 @@ async fn forward(
         while let Some((topic, e)) = rx.recv().await {
             // While ttrpc push the event,give it a 5 seconds timeout.
             // Prevent event reporting from taking too long time.
-            // Learnd from goshim's containerd/runtime/v2/shim/publisher.go
+            // Learned from goshim's containerd/runtime/v2/shim/publisher.go
             publisher
                 .publish(with_timeout(5000000000), &topic, &ns, e)
                 .await

--- a/crates/runc/README.md
+++ b/crates/runc/README.md
@@ -42,5 +42,5 @@ async fn main() {
     - kill
     - delete
 - Exec is **not** available in `RuncAsyncClient` now.
-- Console utilites are **not** available
+- Console utilities are **not** available
     - see [Go version](https://github.com/containerd/go-runc/blob/main/console.go)

--- a/crates/runc/src/error.rs
+++ b/crates/runc/src/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[error(transparent)]
     ProcessSpawnFailed(io::Error),
 
-    #[error("Error occured in runc: {0}")]
+    #[error("Error occurred in runc: {0}")]
     InvalidCommand(io::Error),
 
     #[error("Runc command failed: status={status}, stdout=\"{stdout}\", stderr=\"{stderr}\"")]
@@ -113,7 +113,7 @@ pub enum Error {
     #[error("Sorry, this part of api is not implemented: {0}")]
     Unimplemented(String),
 
-    #[error("Error occured in runc client: {0}")]
+    #[error("Error occurred in runc client: {0}")]
     Other(Box<dyn std::error::Error + Send>),
 
     #[error("Failed to set cmd io: {0}")]

--- a/crates/runc/src/events.rs
+++ b/crates/runc/src/events.rs
@@ -125,10 +125,10 @@ pub struct Throttling {
     pub periods: Option<u64>,
     #[serde(rename = "throttledPeriods")]
     /// Number of periods when the container hit its throttling limit
-    pub throtted_periods: Option<u64>,
+    pub throttled_periods: Option<u64>,
     /// Aggregate time the container was throttled for in nanoseconds
     #[serde(rename = "throttledTime")]
-    pub throtted_time: Option<u64>,
+    pub throttled_time: Option<u64>,
 }
 
 /// Each members represents time in nanoseconds

--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -978,7 +978,7 @@ mod tests {
             }
         })
         .await
-        .expect("tokio spawn falied.");
+        .expect("tokio spawn failed.");
     }
 
     #[tokio::test]
@@ -1013,7 +1013,7 @@ mod tests {
             }
         })
         .await
-        .expect("tokio spawn falied.");
+        .expect("tokio spawn failed.");
     }
 
     #[tokio::test]

--- a/crates/runc/src/monitor.rs
+++ b/crates/runc/src/monitor.rs
@@ -43,7 +43,7 @@ pub trait ProcessMonitor {
     /// respectively, when creating the [Command](https://docs.rs/tokio/1.16.1/tokio/process/struct.Command.html#).
     async fn start(&self, mut cmd: Command, tx: Sender<Exit>) -> std::io::Result<Output> {
         let chi = cmd.spawn()?;
-        // Safe to expect() because wait() hasn't been called yet, dependence on tokio interanl
+        // Safe to expect() because wait() hasn't been called yet, dependence on tokio internal
         // implementation details.
         let pid = chi
             .id()

--- a/crates/shim/src/asynchronous/publisher.rs
+++ b/crates/shim/src/asynchronous/publisher.rs
@@ -111,7 +111,7 @@ impl RemotePublisher {
                     let sender_ref = sender.clone();
                     // Take a another task requeue , for no blocking the recv task
                     tokio::spawn(async move {
-                        // wait for few time and send for imporving the success ratio
+                        // wait for few time and send for improving the success ratio
                         tokio::time::sleep(tokio::time::Duration::from_secs(new_item.count as u64))
                             .await;
                         // if channel is full and send fail ,release it after 3 seconds

--- a/crates/shim/src/logger.rs
+++ b/crates/shim/src/logger.rs
@@ -60,20 +60,20 @@ impl FifoLogger {
     }
 }
 
-pub(crate) struct SimpleWriteVistor {
+pub(crate) struct SimpleWriteVisitor {
     key_values: String,
 }
 
-impl<'kvs> Visitor<'kvs> for SimpleWriteVistor {
+impl<'kvs> Visitor<'kvs> for SimpleWriteVisitor {
     fn visit_pair(&mut self, k: kv::Key<'kvs>, v: kv::Value<'kvs>) -> Result<(), kv::Error> {
         write!(&mut self.key_values, " {}=\"{}\"", k, v)?;
         Ok(())
     }
 }
 
-impl SimpleWriteVistor {
-    pub(crate) fn new() -> SimpleWriteVistor {
-        SimpleWriteVistor {
+impl SimpleWriteVisitor {
+    pub(crate) fn new() -> SimpleWriteVisitor {
+        SimpleWriteVisitor {
             key_values: String::new(),
         }
     }
@@ -93,7 +93,7 @@ impl log::Log for FifoLogger {
             let mut guard = self.file.lock().unwrap();
 
             // collect key_values but don't fail if error parsing
-            let mut writer = SimpleWriteVistor::new();
+            let mut writer = SimpleWriteVisitor::new();
             let _ = record.key_values().visit(&mut writer);
 
             // The logger server may have temporarily shutdown, ignore the error instead of panic.
@@ -106,7 +106,7 @@ impl log::Log for FifoLogger {
             let _ = writeln!(
                 guard.borrow_mut(),
                 "time=\"{}\" level={}{} msg=\"{}\"\n",
-                rfc3339_formated(),
+                rfc3339_formatted(),
                 record.level().as_str().to_lowercase(),
                 writer.as_str(),
                 record.args()
@@ -155,7 +155,7 @@ fn configure_logging_level(debug: bool, default_log_level: &str) {
     log::set_max_level(level);
 }
 
-pub(crate) fn rfc3339_formated() -> String {
+pub(crate) fn rfc3339_formatted() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or(OffsetDateTime::now_utc().to_string())

--- a/crates/shim/src/mount.rs
+++ b/crates/shim/src/mount.rs
@@ -491,7 +491,7 @@ pub fn mount_rootfs(
                 )
                 .unwrap_or_else(|err| {
                     error!(
-                        "Change {} mount propagation faied: {}",
+                        "Change {} mount propagation failed: {}",
                         target.as_ref().display(),
                         err
                     );

--- a/crates/shim/src/synchronous/mod.rs
+++ b/crates/shim/src/synchronous/mod.rs
@@ -524,8 +524,8 @@ pub fn spawn(opts: StartOpts, grouping: &str, vars: Vec<(&str, &str)>) -> Result
     #[cfg(windows)]
     {
         // Activation pattern for Windows comes from the hcsshim: https://github.com/microsoft/hcsshim/blob/v0.10.0-rc.7/cmd/containerd-shim-runhcs-v1/serve.go#L57-L70
-        // another way to do it would to create named pipe and pass it to the child process through handle inheritence but that would require duplicating
-        // the logic in Rust's 'command' for process creation.  There is an  issue in Rust to make it simplier to specify handle inheritence and this could
+        // another way to do it would to create named pipe and pass it to the child process through handle inheritance but that would require duplicating
+        // the logic in Rust's 'command' for process creation.  There is an  issue in Rust to make it simpler to specify handle inheritance and this could
         // be revisited once https://github.com/rust-lang/rust/issues/54760 is implemented.
         let (mut reader, writer) = os_pipe::pipe().map_err(io_error!(e, "create pipe"))?;
         let stdio_writer = writer.try_clone().unwrap();

--- a/crates/shim/src/sys/windows/named_pipe_logger.rs
+++ b/crates/shim/src/sys/windows/named_pipe_logger.rs
@@ -85,12 +85,12 @@ impl log::Log for NamedPipeLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             // collect key_values but don't fail if error parsing
-            let mut writer = logger::SimpleWriteVistor::new();
+            let mut writer = logger::SimpleWriteVisitor::new();
             let _ = record.key_values().visit(&mut writer);
 
             let message = format!(
                 "time=\"{}\" level={}{} msg=\"{}\"\n",
-                logger::rfc3339_formated(),
+                logger::rfc3339_formatted(),
                 record.level().as_str().to_lowercase(),
                 writer.as_str(),
                 record.args()

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -119,7 +119,7 @@ impl AddAssign for Usage {
 pub trait Snapshotter: Send + Sync + 'static {
     /// Error type returned from the underlying snapshotter implementation.
     ///
-    /// This type must be convertable to GRPC status.
+    /// This type must be convertible to GRPC status.
     type Error: Debug + Into<tonic::Status> + Send;
 
     /// Returns the info for an active or committed snapshot by name or key.

--- a/deny.toml
+++ b/deny.toml
@@ -66,7 +66,7 @@ ignore = [
 [licenses]
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
@@ -76,7 +76,7 @@ allow = [
     "BSD-3-Clause",
     "Unicode-3.0",
 ]
-# List of explictly disallowed licenses
+# List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [


### PR DESCRIPTION
breaking changes:
- `Throttling` struct field name `throtted_periods` -> `throttled_periods`
- `Throttling` struct field name `throtted_time` -> `throttled_time`
- `SimpleWriteVistor` -> `SimpleWriteVisitor`

This commit also adds a spell checking workflow to the repository.