### PR TITLE
Use same activation strategy in all platforms

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -72,9 +72,6 @@ tokio = { workspace = true, features = ["full"], optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-command-fds = "0.3.0"
-
 [target.'cfg(windows)'.dependencies]
 mio = { version = "1.0", features = ["os-ext", "os-poll"] }
 windows-sys = { version = "0.52.0", features = [

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -77,7 +77,6 @@ command-fds = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 mio = { version = "1.0", features = ["os-ext", "os-poll"] }
-os_pipe.workspace = true
 windows-sys = { version = "0.52.0", features = [
   "Win32_Foundation",
   "Win32_System_WindowsProgramming",

--- a/crates/shim/src/error.rs
+++ b/crates/shim/src/error.rs
@@ -49,11 +49,6 @@ pub enum Error {
     #[error("Failed to setup logger: {0}")]
     Setup(#[from] log::SetLoggerError),
 
-    /// Unable to pass fd to child process (we rely on `command_fds` crate for this).
-    #[cfg(unix)]
-    #[error("Failed to pass socket fd to child: {0}")]
-    FdMap(#[from] command_fds::FdMappingCollision),
-
     #[cfg(unix)]
     #[error("Nix error: {0}")]
     Nix(#[from] nix::Error),

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -18,10 +18,7 @@
 
 use std::{fs::File, path::PathBuf};
 #[cfg(unix)]
-use std::{
-    os::unix::{io::RawFd, net::UnixListener},
-    path::Path,
-};
+use std::{os::unix::net::UnixListener, path::Path};
 
 pub use containerd_shim_protos as protos;
 #[cfg(unix)]
@@ -150,12 +147,6 @@ pub struct StartOpts {
 
     pub debug: bool,
 }
-
-/// The shim process communicates with the containerd server through a communication channel
-/// created by containerd. One endpoint of the communication channel is passed to shim process
-/// through a file descriptor during forking, which is the fourth(3) file descriptor.
-#[cfg(unix)]
-const SOCKET_FD: RawFd = 3;
 
 #[cfg(target_os = "linux")]
 pub const SOCKET_ROOT: &str = "/run/containerd";


### PR DESCRIPTION
Currently the sync code uses two different activation strategies:
* **In Unix:** The server listener is bound in the parent process, and passes the FD to the child processes.
* **In Windows:** The server listener is directly bound in the child process, and a pipe is used for the parent to wait until the binding is completed.

This PR unified the activation strategy on all platforms, following the strategy used for Windows.
Additionally, it avoids computing the listener address twice by reusing the `-socket` flag when spawning the child process.

This PR also applies the same activation strategy to the async code.

The main motivation for this PR is to eventually support Windows on the async feature.
