### PR TITLE
Remove dependency on signal-hook-tokio

### DIFF
--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -19,7 +19,6 @@ async = [
   "async-trait",
   "containerd-shim-protos/async",
   "futures",
-  "signal-hook-tokio",
   "tokio",
 ]
 tracing = ["dep:tracing"]
@@ -64,9 +63,6 @@ tracing = { version = "0.1", optional = true }
 # Async dependencies
 async-trait = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
-signal-hook-tokio = { version = "0.3.1", optional = true, features = [
-  "futures-v0_3",
-] }
 tokio = { workspace = true, features = ["full"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
The `signal-hook-tokio` package is now integrated into tokio in the `signals` feature.
Moreover, the `signal-hook-tokio` crates is unix only (see https://github.com/vorner/signal-hook/issues/100#issuecomment-804334820), while the tokio impl also supports windows.

This PR is part of the effort to add Windows support for the async feature.