### PR TITLE
Re-enable cargo machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,10 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
-      # See https://github.com/containerd/rust-extensions/issues/348
-      # - name: check unused dependencies
-      #   uses: bnjbvr/cargo-machete@v0.7.0
+      - name: check unused dependencies
+        uses: bnjbvr/cargo-machete@v0.7.0
+        env:
+          RUSTUP_TOOLCHAIN: "stable"
 
   # TODO: Merge this with the checks job above
   windows-checks:

--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -36,7 +36,6 @@ serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
 uuid.workspace = true
-tempfile.workspace = true
 # Async dependencies
 async-trait.workspace = true
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
~~With https://github.com/containerd/rust-extensions/commit/6ad0a6e0d37c42a7d5b8c7f5ece57d6eeada2410 we should be able to re-enable cargo machete.~~
Turns out cargo machete now requires 2024 edition, which requires rust 1.85+

Fixes #348