### PR TITLE
pin grcov version

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install grcov
         run: |
-          cargo install --locked grcov
+          cargo install --locked grcov@0.8.24
           grcov --version
 
       - name: Tests


### PR DESCRIPTION
Recently CI has been failing due to an update to grcov, Foe example, [here](https://github.com/containerd/rust-extensions/actions/runs/14349512282/job/40225446691?pr=389)
```
Run grcov . \
Error: 3 [ERROR] A panic occurred at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/grcov-0.9.0/src/llvm_tools.rs:95: called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
Error: 3 [ERROR] A panic occurred at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/grcov-0.9.0/src/llvm_tools.rs:95: called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
Error: 3 [ERROR] A panic occurred at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ignore-0.4.23/src/walk.rs:[13](https://github.com/containerd/rust-extensions/actions/runs/14349512282/job/40225446691?pr=389#step:6:14)01: called `Result::unwrap()` on an `Err` value: Any { .. }
Error: 3 [ERROR] A panic occurred at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/grcov-0.9.0/src/llvm_tools.rs:95: called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
Error: Process completed with exit code 1.
```

This PR pins the grcov version to unblock CI.