### PR TITLE
chore: Move tokio dependency in `snapshots` to dev dependency

### DIFF
--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -26,13 +26,13 @@ prost-types.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tonic.workspace = true
-tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.8"
 
 [dev-dependencies]
 futures.workspace = true
 log.workspace = true
 simple_logger.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 
 [build-dependencies]
 tonic-build.workspace = true


### PR DESCRIPTION
- `tokio_stream` is a direct dependency, and it depends  on `tokio`. We don't need to re-add `tokio` here as a direct dependency 

tl;dr - relax tokio constraint to that of what is specified by `tokio_stream`