### PR TITLE
chore: Update protobuf definitions using latest containerd version v2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        containerd: [v1.6.38, v1.7.27, v2.0.5]
+        os: [ubuntu-latest]
+        containerd: [v1.6.38, v1.7.27, v2.1.1]
 
     steps:
       - name: Checkout extensions

--- a/crates/client/vendor/github.com/containerd/containerd/api/events/content.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/events/content.proto
@@ -23,6 +23,11 @@ import "github.com/containerd/containerd/api/types/fieldpath.proto";
 option go_package = "github.com/containerd/containerd/api/events;events";
 option (containerd.types.fieldpath_all) = true;
 
+message ContentCreate {
+	string digest = 1;
+	int64 size = 2;
+}
+
 message ContentDelete {
 	string digest = 1;
 }

--- a/crates/client/vendor/github.com/containerd/containerd/api/services/images/v1/images.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/services/images/v1/images.proto
@@ -145,5 +145,5 @@ message DeleteImageRequest {
 	//
 	// If image descriptor does not match the same digest,
 	// the delete operation will return "not found" error.
-	containerd.types.Descriptor target = 3;
+	optional containerd.types.Descriptor target = 3;
 }

--- a/crates/client/vendor/github.com/containerd/containerd/api/types/fieldpath.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/types/fieldpath.proto
@@ -34,9 +34,9 @@ import "google/protobuf/descriptor.proto";
 option go_package = "github.com/containerd/containerd/api/types;types";
 
 extend google.protobuf.FileOptions {
-	bool fieldpath_all = 63300;
+	optional bool fieldpath_all = 63300;
 }
 
 extend google.protobuf.MessageOptions {
-	bool fieldpath = 64400;
+	optional bool fieldpath = 64400;
 }

--- a/crates/client/vendor/github.com/containerd/containerd/api/types/transfer/registry.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/api/types/transfer/registry.proto
@@ -27,6 +27,16 @@ message OCIRegistry {
 	RegistryResolver resolver = 2;
 }
 
+enum HTTPDebug {
+	DISABLED = 0;
+	// Enable HTTP debugging
+	DEBUG = 1;
+	// Enable HTTP requests tracing
+	TRACE = 2;
+	// Enable both HTTP debugging and requests tracing
+	BOTH = 3;
+}
+
 message RegistryResolver {
 	// auth_stream is used to refer to a stream which auth callbacks may be
 	// made on.
@@ -40,6 +50,13 @@ message RegistryResolver {
 	string default_scheme = 4;
 	// Force skip verify
 	// CA callback? Client TLS callback?
+
+	// Whether to debug/trace HTTP requests to OCI registry.
+	HTTPDebug http_debug = 5;
+
+	// Stream ID to use for HTTP logs (when logs are streamed to client).
+	// When empty, logs are written to containerd logs.
+	string logs_stream = 6;
 }
 
 // AuthRequest is sent as a callback on a stream

--- a/crates/client/vendor/github.com/containerd/containerd/vendor/github.com/containerd/containerd/api/events/content.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/vendor/github.com/containerd/containerd/api/events/content.proto
@@ -23,6 +23,11 @@ import "github.com/containerd/containerd/api/types/fieldpath.proto";
 option go_package = "github.com/containerd/containerd/api/events;events";
 option (containerd.types.fieldpath_all) = true;
 
+message ContentCreate {
+	string digest = 1;
+	int64 size = 2;
+}
+
 message ContentDelete {
 	string digest = 1;
 }

--- a/crates/client/vendor/github.com/containerd/containerd/vendor/github.com/containerd/containerd/api/types/transfer/registry.proto
+++ b/crates/client/vendor/github.com/containerd/containerd/vendor/github.com/containerd/containerd/api/types/transfer/registry.proto
@@ -27,6 +27,16 @@ message OCIRegistry {
 	RegistryResolver resolver = 2;
 }
 
+enum HTTPDebug {
+	DISABLED = 0;
+	// Enable HTTP debugging
+	DEBUG = 1;
+	// Enable HTTP requests tracing
+	TRACE = 2;
+	// Enable both HTTP debugging and requests tracing
+	BOTH = 3;
+}
+
 message RegistryResolver {
 	// auth_stream is used to refer to a stream which auth callbacks may be
 	// made on.
@@ -40,6 +50,13 @@ message RegistryResolver {
 	string default_scheme = 4;
 	// Force skip verify
 	// CA callback? Client TLS callback?
+
+	// Whether to debug/trace HTTP requests to OCI registry.
+	HTTPDebug http_debug = 5;
+
+	// Stream ID to use for HTTP logs (when logs are streamed to client).
+	// When empty, logs are written to containerd logs.
+	string logs_stream = 6;
 }
 
 // AuthRequest is sent as a callback on a stream

--- a/scripts/update-vendor.sh
+++ b/scripts/update-vendor.sh
@@ -8,7 +8,7 @@
 # For each crate, the script expects a text file named `rsync.txt` in the crate's directory.
 # The file should contain a list of proto files that should be synchronized from containerd.
 
-VERSION="v2.0.1"
+VERSION="v2.1.1"
 
 set -x
 


### PR DESCRIPTION
Ref https://github.com/containerd/containerd/releases/tag/v2.1.1

Steps:
1. Updated containerd version from `v2.0.1` to `v2.1.1` in `scripts/update-vendor.sh` 
2. Execute `./scripts/update-vendor.sh`

the Github workflow CI file was manually edited to match the version change