### PR TITLE
chore: Update protobuf dependency to latest

### DIFF
--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -53,7 +53,9 @@ protobuf = "3.7.2"
 ttrpc = "0.8.3"
 
 [build-dependencies]
-ttrpc-codegen = "0.4.2"
+# TODO - replace git sha with next version that incudes the changes from the sha below
+# ttrpc-codegen = "0.5.0"
+ttrpc-codegen = { git = "https://github.com/containerd/ttrpc-rust", rev = "4929e9079941e7ead82fae3911340f8cbe810e7e" }
 
 [dev-dependencies]
 ctrlc = { version = "3.0", features = ["termination"] }

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -49,9 +49,7 @@ required-features = ["async"]
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
-# protobuf 3.5 introduces a breaking change: https://github.com/containerd/rust-extensions/issues/295
-# pinning to <3.5.0 until we can update the generated code
-protobuf = ">= 3.0, <3.5.0"
+protobuf = "3.7.2"
 ttrpc = "0.8.3"
 
 [build-dependencies]

--- a/crates/shim-protos/examples/ttrpc-server-async.rs
+++ b/crates/shim-protos/examples/ttrpc-server-async.rs
@@ -60,7 +60,7 @@ impl Task for FakeServer {
 async fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let tservice = create_task(Arc::new(Box::new(FakeServer::new())));
+    let tservice = create_task(Arc::new(FakeServer::new()));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/examples/ttrpc-server.rs
+++ b/crates/shim-protos/examples/ttrpc-server.rs
@@ -57,7 +57,7 @@ impl Task for FakeServer {
 fn main() {
     simple_logger::SimpleLogger::new().init().unwrap();
 
-    let tservice = create_task(Arc::new(Box::new(FakeServer::new())));
+    let tservice = create_task(Arc::new(FakeServer::new()));
 
     let mut server = Server::new()
         .bind("unix:///tmp/shim-proto-ttrpc-001")

--- a/crates/shim-protos/tests/ttrpc.rs
+++ b/crates/shim-protos/tests/ttrpc.rs
@@ -72,7 +72,7 @@ fn create_ttrpc_context() -> (
 
 #[test]
 fn test_task_method_num() {
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let task = create_task(Arc::new(FakeServer::new()));
     assert_eq!(task.len(), 17);
 }
 
@@ -96,7 +96,7 @@ fn test_create_task() {
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
 
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let task = create_task(Arc::new(FakeServer::new()));
     let create = task.get("/containerd.task.v2.Task/Create").unwrap();
     create.handler(ctx, request).unwrap();
 
@@ -137,7 +137,7 @@ fn test_delete_task() {
     request.set_timeout_nano(10000);
     request.set_metadata(ttrpc::context::to_pb(ctx.metadata.clone()));
 
-    let task = create_task(Arc::new(Box::new(FakeServer::new())));
+    let task = create_task(Arc::new(FakeServer::new()));
     let delete = task.get("/containerd.task.v2.Task/Delete").unwrap();
     delete.handler(ctx, request).unwrap();
 

--- a/crates/shim/src/asynchronous/publisher.rs
+++ b/crates/shim/src/asynchronous/publisher.rs
@@ -223,7 +223,7 @@ mod tests {
         let barrier2 = barrier.clone();
         let server_thread = tokio::spawn(async move {
             let listener = UnixListener::bind(&path1).unwrap();
-            let service = create_events(Arc::new(Box::new(server)));
+            let service = create_events(Arc::new(server));
             let mut server = Server::new()
                 .set_domain_unix()
                 .add_listener(listener.as_raw_fd())

--- a/crates/shim/src/synchronous/publisher.rs
+++ b/crates/shim/src/synchronous/publisher.rs
@@ -200,7 +200,7 @@ mod tests {
 
         #[cfg(windows)]
         {
-            let service = client::create_events(Arc::new(Box::new(FakeServer {})));
+            let service = client::create_events(Arc::new(FakeServer {}));
 
             Server::new()
                 .bind(server_address)


### PR DESCRIPTION
Previous versions failed and the version had to be restricted; this no longer appears to be an issue

Ref: #295
Ref: #296

Closes #327

- 2nd commit bumps `ttrpc-codegen` to align protobuf versions. We can revert to a standard crate version on the next release of `ttrpc-codegen`. See https://github.com/containerd/ttrpc-rust/pull/291

Closes #364 