### PR TITLE
truncate backing file path exceeding 64 bytes in LoopInfo

### DIFF
--- a/crates/shim/src/mount_linux.rs
+++ b/crates/shim/src/mount_linux.rs
@@ -791,7 +791,13 @@ pub fn setup_loop_dev(backing_file: &str, loop_dev: &str, params: &LoopParams) -
     }
     // 3. set info
     let mut info = LoopInfo::default();
-    info.file_name[..backing_file.as_bytes().len()].copy_from_slice(backing_file.as_bytes());
+    let backing_file_truncated = if backing_file.as_bytes().len() > info.file_name.len() {
+        &backing_file[0..info.file_name.len()]
+    } else {
+        backing_file
+    };
+    info.file_name[..backing_file_truncated.as_bytes().len()]
+        .copy_from_slice(backing_file_truncated.as_bytes());
     if params.readonly {
         info.flags |= LO_FLAGS_READ_ONLY;
     }


### PR DESCRIPTION
When the backing file path exceeds 64 bytes, an 'out of range' error occurs due to the limitation of the `file_name` field in `LoopInfo`. This commit truncates the file path to ensure it does not exceed the maximum supported length, preventing the error while maintaining usability.