### PR TITLE
fix(shim): Under certain extreme conditions, the kill cannot be completed immedetaly

### DIFF
--- a/crates/shim/src/error.rs
+++ b/crates/shim/src/error.rs
@@ -79,6 +79,9 @@ pub enum Error {
     #[error("Failed to send exit event: {0}")]
     Send(#[from] std::sync::mpsc::SendError<ExitEvent>),
 
+    #[error("Deadline exceeded: {0}")]
+    DeadlineExceeded(String),
+
     #[error("Other: {0}")]
     Other(String),
 


### PR DESCRIPTION
problem:
I meet this conditions in the environment.
<img width="952" height="70" alt="image" src="https://github.com/user-attachments/assets/b9d38dac-0f85-44a0-b051-3a9351c19b3b" />

The shim's process 1836918 can't be killed, because the 1836918 is in do_wait call in kernel, so it can't  return the kill system call.
the stack is 
<img width="444" height="202" alt="image" src="https://github.com/user-attachments/assets/21d02d7b-3712-4a25-a5e1-0b6934d26bb9" />

and the son process 1902406 of 1836918 is zombie, The most direct issue is that shim cannot respond to any information about the container.

resolution:
Let kill call in single task for not holding the lock.This can prevent other GRPC requests from being blocked which is belong to this container.