### PR TITLE
fix(task): update debug is useless

### DIFF
--- a/crates/runc-shim/src/task.rs
+++ b/crates/runc-shim/src/task.rs
@@ -391,7 +391,7 @@ where
     }
 
     async fn update(&self, _ctx: &TtrpcContext, mut req: UpdateTaskRequest) -> TtrpcResult<Empty> {
-        debug!("Update request for {:?}", req);
+        debug!("Update request for id {:?}", req.id);
 
         let id = req.take_id();
 
@@ -407,6 +407,7 @@ where
                 format!("failed to parse resource spec: {}", e),
             ))
         })?;
+        debug!("Update resource is {:?}", resources);
         self.container_mut(&id).await?.update(&resources).await?;
         Ok(Empty::new())
     }


### PR DESCRIPTION
The debug message in MessageFiled<Any> is useless. Better debug printing information helps locate issues.
before like this 

level=debug msg="Update request for UpdateTaskRequest { id: "e009134f5ce4deb7a3db7698505c0748cb767c9719de05cc3aa15a158b7f7789", resources: MessageField(Some(Any { type_url: "types.containerd.io/opencontainers/runtime-spec/1/LinuxResources", value: [123, 34, 100, 101, 118, 105, 99, 101, 115, 34, 58, 91, 123, 34, 97, 108, 108, 111, 119, 34, 58, 102, 97, 108, 115, 101, 44, 34, 97, 99, 99, 101, 115, 115, 34, 58, 34, 114, 119, 109, 34, 125, 93, 44, 34, 109, 101, 109, 111, 114, 121, 34, 58, 123, 125, 44, 34, 99, 112, 117, 34, 58, 123, 34, 99, 112, 117, 115, 34, 58, 34, 51, 34, 125, 125], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } })), annotations: {}, special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"

after like this:
level=debug msg="Update request for id "352777dfccf5688aa458a12f38a59454f103037612bfdedf80c36867f1eb01e6""
level=debug msg="Update resource is LinuxResources { devices: Some([LinuxDeviceCgroup { allow: false, typ: None, major: None, minor: None, access: Some("rwm") }]), memory: Some(LinuxMemory { limit: None, reservation: None, swap: None, kernel: None, kernel_tcp: None, swappiness: None, disable_oom_killer: None, use_hierarchy: None, check_before_update: None }), cpu: Some(LinuxCpu { shares: None, quota: None, idle: None, burst: None, period: None, realtime_runtime: None, realtime_period: None, cpus: Some("3"), mems: None }), pids: None, block_io: None, hugepage_limits: None, network: None, rdma: None, unified: None }"