### PR TITLE
fix(pty) : Use more safe package rustix to resize pty

### DIFF
--- a/crates/runc-shim/Cargo.toml
+++ b/crates/runc-shim/Cargo.toml
@@ -39,6 +39,10 @@ uuid.workspace = true
 # Async dependencies
 async-trait.workspace = true
 tokio = { workspace = true, features = ["full"] }
+rustix = { version = "1", features = ["termios"] }
+
+[package.metadata.cargo-machete]
+ignored = ["libc"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs.workspace = true

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -17,24 +17,17 @@
 #![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
 
 use std::{fs::File, path::PathBuf};
+#[cfg(windows)]
+use std::{fs::OpenOptions, os::windows::prelude::OpenOptionsExt};
 #[cfg(unix)]
 use std::{os::unix::net::UnixListener, path::Path};
 
 pub use containerd_shim_protos as protos;
-#[cfg(unix)]
-use nix::ioctl_write_ptr_bad;
 pub use protos::{
     shim::shim::DeleteResponse,
     ttrpc::{context::Context, Result as TtrpcResult},
 };
 use sha2::{Digest, Sha256};
-
-#[cfg(unix)]
-ioctl_write_ptr_bad!(ioctl_set_winsz, libc::TIOCSWINSZ, libc::winsize);
-
-#[cfg(windows)]
-use std::{fs::OpenOptions, os::windows::prelude::OpenOptionsExt};
-
 #[cfg(windows)]
 use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 


### PR DESCRIPTION
avoid using the nix's unsafe ioctl call