### PR TITLE
log: Use the local system time instead of hardcoding UTC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 simple_logger = { version = "5.0", default-features = false }
 tempfile = "3.6"
 thiserror = "2.0"
-time = { version = "0.3.29", features = ["serde", "std", "formatting"] }
+time = { version = "0.3.44", features = ["serde", "std", "formatting", "local-offset"] }
 tokio = "1.26"
 tonic = "0.14"
 tonic-prost = "0.14"

--- a/crates/shim/src/logger.rs
+++ b/crates/shim/src/logger.rs
@@ -207,7 +207,8 @@ fn configure_logging_level(debug: bool, default_log_level: &str) {
 }
 
 pub(crate) fn rfc3339_formated() -> String {
-    OffsetDateTime::now_utc()
+    OffsetDateTime::now_local()
+        .unwrap_or(OffsetDateTime::now_utc())
         .format(&Rfc3339)
         .unwrap_or(OffsetDateTime::now_utc().to_string())
 }


### PR DESCRIPTION
Use the local system time instead of hardcoding UTC.

Update `time` from 0.3.29 to 0.3.44. `time::OffsetDateTime::now_local()` will return error in 0.3.29.