### PR TITLE
ci: declare contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Checks


### PR DESCRIPTION
The nine jobs in `ci.yml` all run `actions/checkout` plus build/test steps. None push or call write APIs, so `contents: read` at the workflow level is the right minimum.

The other CI-adjacent workflows in this repo (`cover.yml`, `labeler.yml`, `publish.yml`, `stale.yml`) already declare `permissions:` per job; this brings `ci.yml` in line with the broader pattern.