### PR TITLE
test(shim): skip privileged tests without required permissions

### DIFF
--- a/crates/shim/src/cgroup.rs
+++ b/crates/shim/src/cgroup.rs
@@ -350,10 +350,10 @@ pub fn update_resources(cgroup: &Cgroup, resources: &LinuxResources) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{error::Error as _, path::PathBuf};
 
     use cgroups_rs::{
-        fs::{hierarchies, Cgroup},
+        fs::{error::ErrorKind, hierarchies, Cgroup},
         CgroupPid,
     };
 
@@ -362,16 +362,37 @@ mod tests {
         add_task_to_cgroup, adjust_oom_score, read_process_oom_score, OOM_SCORE_ADJ_MAX,
     };
 
+    fn is_cgroup_permission_error(err: &cgroups_rs::fs::error::Error) -> bool {
+        *err.kind() == ErrorKind::FsError
+            && err
+                .source()
+                .and_then(|source| source.downcast_ref::<std::io::Error>())
+                .is_some_and(|source| source.kind() == std::io::ErrorKind::PermissionDenied)
+    }
+
     #[test]
     fn test_add_cgroup() {
         let path = "runc_shim_test_cgroup";
         let h = hierarchies::auto();
 
         // create cgroup path first
-        let cg = Cgroup::new(h, path).unwrap();
+        let cg = match Cgroup::new(h, path) {
+            Ok(cg) => cg,
+            Err(err) if is_cgroup_permission_error(&err) => {
+                eprintln!("skipping test_add_cgroup: {err}");
+                return;
+            }
+            Err(err) => panic!("failed to create cgroup for test: {err}"),
+        };
 
         let pid = std::process::id();
-        add_task_to_cgroup(path, pid).unwrap();
+        if let Err(err) = add_task_to_cgroup(path, pid) {
+            if crate::error::is_permission_error(&err) {
+                eprintln!("skipping test_add_cgroup: {err}");
+                return;
+            }
+            panic!("failed to add task to cgroup for test: {err}");
+        }
         let cg_id = CgroupPid::from(pid as u64);
         assert!(cg.tasks().contains(&cg_id));
 

--- a/crates/shim/src/error.rs
+++ b/crates/shim/src/error.rs
@@ -89,6 +89,21 @@ pub enum Error {
     Unimplemented(String),
 }
 
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn is_permission_error(err: &Error) -> bool {
+    match err {
+        Error::IoError { err, .. } => err.kind() == std::io::ErrorKind::PermissionDenied,
+        #[cfg(unix)]
+        Error::Nix(err) | Error::MountError { err, .. } => {
+            matches!(err, nix::errno::Errno::EACCES | nix::errno::Errno::EPERM)
+        }
+        Error::Other(msg) => {
+            msg.contains("Permission denied") || msg.contains("Operation not permitted")
+        }
+        _ => false,
+    }
+}
+
 impl From<Error> for ttrpc::Error {
     fn from(e: Error) -> Self {
         match e {

--- a/crates/shim/src/mount_linux.rs
+++ b/crates/shim/src/mount_linux.rs
@@ -1139,7 +1139,13 @@ mod tests {
         ];
         // mount target.
         let result = mount_rootfs(Some("overlay"), Some("overlay"), &options, &target);
-        assert!(result.is_ok());
+        if let Err(err) = &result {
+            if crate::error::is_permission_error(err) {
+                eprintln!("skipping test_mount_rootfs_umount_recursive: {err}");
+                return;
+            }
+        }
+        assert!(result.is_ok(), "{result:?}");
         let mut mountinfo = get_mounts(Some(prefix_filter(
             target
                 .path()
@@ -1176,6 +1182,12 @@ mod tests {
             direct: true,
         };
         let result = setup_loop(backing_file, params);
-        assert!(result.is_ok());
+        if let Err(err) = &result {
+            if crate::error::is_permission_error(err) {
+                eprintln!("skipping test_setup_loop_dev: {err}");
+                return;
+            }
+        }
+        assert!(result.is_ok(), "{result:?}");
     }
 }


### PR DESCRIPTION
normal `cargo test -p containerd-shim --lib` can fail on a non-root linux box, even when nothing is wrong with the code.

this keeps the privileged tests strict, but bails out early when the host just does not allow cgroup writes, overlay mounts, or loop device setup. so local runs stop tripping over env stuff, neat and simple.

repro:
1. use a regular non-root shell on linux
2. run `cargo +stable test -p containerd-shim --lib`
3. run `cargo +stable test -p containerd-shim --lib --features async`
4. before this patch you can hit `Permission denied` from `test_add_cgroup` or `test_setup_loop_dev`, and overlay mount can fail too

checks:
- `cargo +stable check -p containerd-shim --all-targets`
- `cargo +stable test -p containerd-shim --lib`
- `cargo +stable test -p containerd-shim --lib --features async`
- `cargo +stable test -p runc --lib`
