### PR TITLE
docs(runc): fix async README example

### DIFF
--- a/crates/runc/README.md
+++ b/crates/runc/README.md
@@ -9,28 +9,31 @@ A crate for consuming the runc binary in your Rust applications, similar to [go-
 This crate is based on archived [rust-runc](https://github.com/pwFoo/rust-runc).
 
 ## Usage
-Both sync/async version is available.
-You can build runc client with `RuncConfig` in method chaining style.
-Call `build()` or `build_async()` to get client.
-Note that async client depends on [tokio](https://github.com/tokio-rs/tokio), then please use it on tokio runtime.
+Both sync and async versions are available.
+You can build a runc client with `GlobalOpts` in method chaining style.
+Call `build()` to get a client.
+To use the async client, enable the `async` feature and run it on a [tokio](https://github.com/tokio-rs/tokio) runtime.
 
 ```rust,ignore
 #[tokio::main]
 async fn main() {
-    let config = runc::GlobalOpts::new()
+    let config = runc::options::GlobalOpts::new()
         .root("./new_root")
         .debug(false)
         .log("/path/to/logfile.json")
         .log_format(runc::LogFormat::Json)
         .rootless(true);
 
-    let client = config.build_async().unwrap();
+    let client = config.build().unwrap();
 
     let opts = runc::options::CreateOpts::new()
         .pid_file("/path/to/pid/file")
         .no_pivot(true);
 
-    client.create("container-id", "path/to/bundle", Some(&opts)).unwrap();
+    client
+        .create("container-id", "path/to/bundle", Some(&opts))
+        .await
+        .unwrap();
 }
 ```
 


### PR DESCRIPTION
Fixes the async `runc` README snippet, it was a bit stale.

Repro
1. Make a tiny crate with `runc` async feature and `tokio`.
2. Copy the old snippet from `crates/runc/README.md`.
3. Run `cargo check`.

It fails because `runc::GlobalOpts` and `build_async()` are not in the current API, and `create(...)` needs `.await`.

This updates the sample to the current API. Small fix, but it saves a head scratch.
Related: #157