### PR TITLE
docs: mention protoc build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rust extensions for containerd
 
-[![CI](https://github.com/mxpv/shim-rs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mxpv/shim-rs/actions/workflows/ci.yml)
+[![CI](https://github.com/containerd/rust-extensions/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/containerd/rust-extensions/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/containerd/rust-extensions/graph/badge.svg?token=VPUPN3MOFX)](https://codecov.io/gh/containerd/rust-extensions)
 [![Crates.io](https://img.shields.io/crates/l/containerd-client)](https://github.com/containerd/rust-extensions/blob/main/LICENSE)
 [![dependency status](https://deps.rs/repo/github/containerd/rust-extensions/status.svg)](https://deps.rs/repo/github/containerd/rust-extensions)
@@ -20,7 +20,9 @@ This repository contains the following crates:
 | [containerd-runc-shim](crates/runc-shim) | Runtime v2 runc shim implementation | [![Crates.io](https://img.shields.io/crates/v/containerd-runc-shim)](https://crates.io/crates/containerd-runc-shim) |
 
 ## How to build
-The build process as easy as:
+Install `protoc` first. The CI workflow does this explicitly via [scripts/install-protobuf.sh](./scripts/install-protobuf.sh), and crates such as `containerd-client` and `containerd-snapshots` require it during `build.rs`.
+
+Once `protoc` is available, build the workspace with:
 ```bash
 cargo build --release
 ```

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -7,6 +7,10 @@
 
 This crate implements a GRPC client to query containerd APIs.
 
+## Build requirements
+
+`protoc` must be installed to build this crate because the gRPC bindings are generated in `build.rs`.
+
 ## Example
 
 Run with `cargo run --example version`

--- a/crates/snapshots/README.md
+++ b/crates/snapshots/README.md
@@ -8,6 +8,10 @@
 Snapshots crate implements containerd's proxy plugin for snapshotting. It aims hide the underlying complexity of GRPC
 interfaces, streaming, and request/response conversions and provide one `Snapshots` trait to implement.
 
+## Build requirements
+
+`protoc` must be installed to build this crate because the gRPC bindings are generated in `build.rs`.
+
 [containerd Documentation](https://github.com/containerd/containerd/blob/main/docs/PLUGINS.md#proxy-plugins)
 
 ## Proxy plugins


### PR DESCRIPTION
Fixes #472

Docs say `cargo build --release`, but `containerd-client` and `containerd-snapshots` need `protoc` in `build.rs`, so a fresh setup can fail pretty fast, kinda a footgun rn.
This adds a short `protoc` note to the root README and the affected crate READMEs. Also fixes the stale root CI badge.

How to repro

1. `PROTOC=/definitely/missing/protoc cargo check -p containerd-client`
2. `PROTOC=/definitely/missing/protoc cargo check -p containerd-snapshots`

Both fail with `Could not find protoc`.

Checked

1. `protoc --version`
2. `cargo check -p containerd-client -p containerd-snapshots`
