### PR TITLE
Use the standard `docsrs` cfg instead of our own `docs` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       - run: cargo clippy --all-targets --target ${{ matrix.target }} -- -D warnings
       - run: cargo clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
 
-      - run: cargo doc --no-deps --features docs
+      - run: cargo +nightly doc --no-deps
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          RUSTDOCFLAGS: "--cfg docsrs -Dwarnings"
 
       - name: check unused dependencies
         uses: bnjbvr/cargo-machete@v0.9.2
@@ -71,9 +71,9 @@ jobs:
       - run: cargo +nightly fmt -p containerd-shim -p containerd-shim-protos -p containerd-client -- --check
 
       - run: cargo clippy -p containerd-shim -p containerd-shim-protos -- -D warnings
-      - run: cargo doc --no-deps -p containerd-shim -p containerd-shim-protos -p containerd-client
+      - run: cargo +nightly doc --no-deps -p containerd-shim -p containerd-shim-protos -p containerd-client
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          RUSTDOCFLAGS: "--cfg docsrs -Dwarnings"
 
   tests:
     name: Tests

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -39,16 +39,12 @@ tokio = { workspace = true, features = ["rt", "macros", "net"] }
 
 [features]
 connect = ["tokio", "tower"]
-docs = []
 
 # Technically Tonic doesn't require Tokio and Tower dependencies here.
 # However we need them to implement `connect` helper and it's highly unlikely
 # that Tonic will be used with any other async runtime (see https://github.com/hyperium/tonic/issues/152)
 # So we enable `connect` feature by default (use `--no-default-features` otherwise).
 default = ["connect"]
-
-[package.metadata.docs.rs]
-features = ["docs"]
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic-prost"]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 // No way to derive Eq with tonic :(
 // See https://github.com/hyperium/tonic/issues/1056
 #![allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -13,9 +13,3 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-
-[features]
-docs = []
-
-[package.metadata.docs.rs]
-features = ["docs"]

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 
 use std::{env, fmt, fs, os::unix::io::FromRawFd, process};
 

--- a/crates/runc/Cargo.toml
+++ b/crates/runc/Cargo.toml
@@ -13,7 +13,6 @@ homepage.workspace = true
 
 [features]
 async = ["tokio", "async-trait", "tokio-pipe"]
-docs = []
 
 [dependencies]
 libc.workspace = true
@@ -30,6 +29,3 @@ time = { workspace = true, features = ["serde", "std"] }
 async-trait = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "sync", "fs", "io-util", "net", "time"], optional = true }
 tokio-pipe = { version = "0.2.12", default-features = false, optional = true }
-
-[package.metadata.docs.rs]
-features = ["docs"]

--- a/crates/runc/src/lib.rs
+++ b/crates/runc/src/lib.rs
@@ -33,7 +33,7 @@
  * limitations under the License.
  */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 
 //! A crate for consuming the runc binary in your Rust applications, similar to
 //! [go-runc](https://github.com/containerd/go-runc) for Go.

--- a/crates/shim-protos/Cargo.toml
+++ b/crates/shim-protos/Cargo.toml
@@ -18,7 +18,6 @@ homepage.workspace = true
 default = []
 async = ["ttrpc/async", "async-trait"]
 sandbox = []
-docs = []
 
 [[example]]
 name = "shim-proto-server"
@@ -60,6 +59,3 @@ ctrlc = { version = "3.5", default-features = false, features = ["termination"] 
 simple_logger = { workspace = true, features = ["stderr"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 crossbeam = { workspace = true, features = ["crossbeam-channel"] } # Used by create_ttrpc_context()
-
-[package.metadata.docs.rs]
-features = ["docs"]

--- a/crates/shim-protos/src/lib.rs
+++ b/crates/shim-protos/src/lib.rs
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 #![allow(warnings)]
 
 pub use protobuf;

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -17,7 +17,6 @@ homepage.workspace = true
 [features]
 async = ["async-trait", "containerd-shim-protos/async", "futures", "tokio"]
 tracing = ["dep:tracing"]
-docs = []
 
 [[example]]
 name = "skeleton_async"
@@ -73,6 +72,3 @@ windows-sys = { version = "0.52.0", default-features = false, features = [
 
 [dev-dependencies]
 tempfile.workspace = true
-
-[package.metadata.docs.rs]
-features = ["docs"]

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -14,7 +14,8 @@
    limitations under the License.
 */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 
 use std::{fmt::Write as _, fs::File, path::PathBuf};
 #[cfg(windows)]

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -14,9 +14,6 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-[features]
-docs = []
-
 [dependencies]
 async-stream = "0.3.6"
 futures = { workspace = true, features = ["std", "alloc"] }
@@ -37,9 +34,6 @@ tonic = { workspace = true, features = ["server", "router"] }
 
 [build-dependencies]
 tonic-prost-build.workspace = true
-
-[package.metadata.docs.rs]
-features = ["docs"]
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic-prost"]

--- a/crates/snapshots/src/lib.rs
+++ b/crates/snapshots/src/lib.rs
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#![cfg_attr(feature = "docs", doc = include_str!("../README.md"))]
+#![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 // No way to derive Eq with tonic :(
 // See https://github.com/hyperium/tonic/issues/1056
 #![allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
docs.rs has failed to build `containerd-shim` since v0.7.0 (0.6.0 is the last release with published docs):

    error[E0658]: `#[doc(cfg)]` is experimental
      --> src/lib.rs:77:32
       |
    77 | #[cfg_attr(docsrs, doc(cfg(not(feature = "async"))))]

`doc(cfg)` requires `#![feature(doc_cfg)]` at the crate root, which was never added. docs.rs is the only place that builds with `--cfg docsrs`, so the attribute activates there and nowhere else, and every local and CI build kept passing.

- Add `#![cfg_attr(docsrs, feature(doc_cfg))]` to the shim crate root. This fixes the broken docs publishing.

- Replace our own `docs` feature with the `docsrs` cfg that docs.rs sets automatically [1]. Both gated the same thing, the README include, so there is no reason to carry a second toggle for it. The `[package.metadata.docs.rs]` blocks go away with it.

Both doc jobs now run on nightly with `--cfg docsrs`, matching what docs.rs actually invokes, so this cannot regress unnoticed again.

[1] https://docs.rs/about/builds